### PR TITLE
feat: add top-level browser export + bare ./browser subpath

### DIFF
--- a/.changeset/browser-export-condition.md
+++ b/.changeset/browser-export-condition.md
@@ -1,0 +1,17 @@
+---
+"@smooai/logger": minor
+---
+
+**Add top-level `browser` export condition + bare `./browser` entry**
+
+`@smooai/logger` already shipped a browser-safe build under `./browser` (exposing `BrowserLogger`, a browser-native `Logger`, and a full `index`), but the top-level `.` entry had no `browser` condition. Browser bundlers therefore resolved `import { Logger } from '@smooai/logger'` to the Node entry, pulling `rotating-file-stream`, `node:fs`, and related Node-only dependencies into the bundle.
+
+Adding the `browser` condition on `.` means consumers can now do:
+
+```ts
+import { Logger } from "@smooai/logger";
+```
+
+…and the bundler automatically picks the browser-safe dist when building for a browser target. No aliasing or explicit `/browser` subpath import required.
+
+Also added a bare `./browser` entry (in addition to the existing `./browser/*` subpath pattern) so `import X from '@smooai/logger/browser'` resolves to `dist/browser/index.*` without needing the explicit `/index` suffix.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,21 +1,36 @@
 {
-    "$schema": "https://json.schemastore.org/claude-code-settings.json",
-    "hooks": {
-        "PreToolUse": [
-            {
-                "matcher": "Edit|Write",
-                "hooks": [{ "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh" }]
-            },
-            {
-                "matcher": "Bash",
-                "hooks": [{ "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh" }]
-            }
-        ],
-        "SessionStart": [
-            {
-                "matcher": "startup",
-                "hooks": [{ "type": "command", "command": "BRANCH=$(git -C \"$CLAUDE_PROJECT_DIR\" symbolic-ref --short HEAD 2>/dev/null); if [[ \"$BRANCH\" == \"main\" || \"$BRANCH\" == \"master\" ]]; then REPO_NAME=$(basename \"$CLAUDE_PROJECT_DIR\"); echo \"⚠️  You are in the MAIN worktree on the main branch. Do NOT do feature work here. Create a worktree first: git worktree add ../${REPO_NAME}-SMOODEV-XX-desc -b SMOODEV-XX-desc main\"; fi" }]
-            }
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
+          }
         ]
-    }
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "BRANCH=$(git -C \"$CLAUDE_PROJECT_DIR\" symbolic-ref --short HEAD 2>/dev/null); if [[ \"$BRANCH\" == \"main\" || \"$BRANCH\" == \"master\" ]]; then REPO_NAME=$(basename \"$CLAUDE_PROJECT_DIR\"); echo \"⚠️  You are in the MAIN worktree on the main branch. Do NOT do feature work here. Create a worktree first: git worktree add ../${REPO_NAME}-SMOODEV-XX-desc -b SMOODEV-XX-desc main\"; fi"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,26 +67,22 @@
   This release transforms `@smooai/logger` into a comprehensive multi-language logging ecosystem:
 
   ### 🐍 Python Package (`smooai-logger`)
-
   - Available on PyPI as `smooai-logger`
   - Full Python implementation with identical API to TypeScript version
   - Synchronized versioning with npm package
 
   ### 🦀 Rust Crate (`smooai-logger`)
-
   - Available on crates.io as `smooai-logger`
   - Native Rust logging implementation
   - Synchronized versioning with npm package
 
   ### 📊 Log Viewer CLI (`smooai-log-viewer`)
-
   - Interactive GUI application for viewing `.smooai-logs` files
   - Available as CLI command when installing npm package: `smooai-log-viewer`
   - Cross-platform native binaries bundled with package
   - Features filtering, searching, JSON expansion, and context viewing
 
   ### 🔄 Automated Publishing Pipeline
-
   - Single changesets release now publishes to npm, PyPI, and crates.io
   - Automatic version synchronization across all packages
   - Enhanced CI/CD workflow for multi-language support

--- a/go/README.md
+++ b/go/README.md
@@ -78,12 +78,12 @@ go get github.com/SmooAI/logger/go/v3
 
 The same structured log format works across all your services:
 
-| Language   | Package | Install |
-| ---------- | ------- | ------- |
-| TypeScript | [`@smooai/logger`](https://www.npmjs.com/package/@smooai/logger) | `pnpm add @smooai/logger` |
-| Python     | [`smooai-logger`](https://pypi.org/project/smooai-logger/) | `pip install smooai-logger` |
-| Rust       | [`smooai-logger`](https://crates.io/crates/smooai-logger) | `cargo add smooai-logger` |
-| Go         | `github.com/SmooAI/logger/go/v3` | `go get github.com/SmooAI/logger/go/v3` |
+| Language   | Package                                                          | Install                                 |
+| ---------- | ---------------------------------------------------------------- | --------------------------------------- |
+| TypeScript | [`@smooai/logger`](https://www.npmjs.com/package/@smooai/logger) | `pnpm add @smooai/logger`               |
+| Python     | [`smooai-logger`](https://pypi.org/project/smooai-logger/)       | `pip install smooai-logger`             |
+| Rust       | [`smooai-logger`](https://crates.io/crates/smooai-logger)        | `cargo add smooai-logger`               |
+| Go         | `github.com/SmooAI/logger/go/v3`                                 | `go get github.com/SmooAI/logger/go/v3` |
 
 ## The Power of Automatic Context
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "browser": {
+        "import": "./dist/browser/index.mjs",
+        "require": "./dist/browser/index.js",
+        "default": "./dist/browser/index.js"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"
@@ -41,6 +46,12 @@
       "types": "./dist/*.d.ts",
       "import": "./dist/*.mjs",
       "require": "./dist/*.js"
+    },
+    "./browser": {
+      "types": "./dist/browser/index.d.ts",
+      "import": "./dist/browser/index.mjs",
+      "require": "./dist/browser/index.js",
+      "default": "./dist/browser/index.js"
     },
     "./browser/*": {
       "types": "./dist/browser/*.d.ts",


### PR DESCRIPTION
## Summary

- Adds `browser` condition to `.` exports so bundlers targeting the browser auto-resolve to the existing `dist/browser/index.*` build
- Adds bare `./browser` subpath entry so `@smooai/logger/browser` works without the `/index` suffix
- Unblocks downstream packages (`@smooai/fetch`, `@smooai/config`) from having to alias `@smooai/logger` manually

## Test plan

- [x] Typecheck + test pass
- [ ] Browser bundle of downstream consumer produces no `rotating-file-stream` / `node:fs` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)