### PR TITLE
fix: silence TS5101 baseUrl deprecation

### DIFF
--- a/.changeset/fix-tsconfig-deprecation.md
+++ b/.changeset/fix-tsconfig-deprecation.md
@@ -1,0 +1,13 @@
+---
+"@smooai/logger": patch
+---
+
+**Silence TS5101 deprecation warning for `baseUrl` in tsconfig**
+
+TypeScript 5.0+ flags the `baseUrl` compiler option as deprecated (to be removed in TS 7.0). The repo's `tsconfig.json` still uses `baseUrl: "./"`; recent Release workflow runs failed during typecheck with:
+
+```
+tsconfig.json: error TS5101: Option 'baseUrl' is deprecated
+```
+
+Adds `"ignoreDeprecations": "5.0"` to quiet the warning until we do a wider tsconfig modernisation. No behavioural change.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "./dist",
     "types": ["node"],
     "target": "ES2022",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "ignoreDeprecations": "5.0"
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx", "tsup.config.ts"],
   "exclude": ["dist", "node_modules", "*.js", "../../node_modules"]


### PR DESCRIPTION
## Summary

- Release workflow has been red since TypeScript started flagging `baseUrl` as deprecated
- Adds `ignoreDeprecations: "5.0"` to tsconfig
- Unblocks publishes (including the pending browser-export v4.1.0)

## Test plan

- [x] `pnpm typecheck` clean locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)