### PR TITLE
fix: drop deprecated baseUrl (second attempt)

### DIFF
--- a/.changeset/drop-baseurl.md
+++ b/.changeset/drop-baseurl.md
@@ -1,0 +1,7 @@
+---
+"@smooai/logger": patch
+---
+
+**Drop deprecated `baseUrl` from tsconfig**
+
+The previous attempt used `ignoreDeprecations: "5.0"` which works locally but CI expects `"6.0"` (depends on exact patch version of TypeScript). Nothing in the codebase relies on baseUrl (no `paths`, no imports start with `./src/...` from a module root), so the cleaner fix is to just remove it. This unblocks the Release workflow which has been red since TypeScript began flagging the deprecation.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,7 @@
     "lib": ["ES2023"],
     "outDir": "./dist",
     "types": ["node"],
-    "target": "ES2022",
-    "baseUrl": "./",
-    "ignoreDeprecations": "5.0"
+    "target": "ES2022"
   },
   "include": ["./src/**/*.ts", "./src/**/*.tsx", "tsup.config.ts"],
   "exclude": ["dist", "node_modules", "*.js", "../../node_modules"]


### PR DESCRIPTION
Previous attempt (PR #132) set \`ignoreDeprecations: "5.0"\` which works locally on TS 5.8.2 but CI wants \`"6.0"\`. Rather than thrash on the exact silence value, drop \`baseUrl\` entirely — nothing in the repo uses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)