### PR TITLE
fix: remove useless .into_iter() (Rust 1.95 clippy)

### DIFF
--- a/.changeset/fix-rust-clippy.md
+++ b/.changeset/fix-rust-clippy.md
@@ -1,0 +1,7 @@
+---
+"@smooai/logger": patch
+---
+
+**Fix Rust clippy `useless_conversion` lint (Rust 1.95)**
+
+Rust 1.95's clippy flags `args.extend(sub.into_iter())` as useless — `.extend()` already accepts `IntoIterator`. Remove the `.into_iter()` call so the Release workflow's lint step passes on the pinned-stable toolchain.

--- a/rust/logger/src/logger.rs
+++ b/rust/logger/src/logger.rs
@@ -538,7 +538,7 @@ impl FromIterator<LogArgs> for LogArgs {
     fn from_iter<T: IntoIterator<Item = LogArgs>>(iter: T) -> Self {
         let mut args = LogArgs::new();
         for sub in iter {
-            args.extend(sub.into_iter());
+            args.extend(sub);
         }
         args
     }


### PR DESCRIPTION
Rust 1.95 clippy flags useless_conversion; remove the `.into_iter()` on `LogArgs::from_iter`. Unblocks Release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)