### PR TITLE
SMOODEV-658: Add SmooAI.Logger .NET port + NuGet publish

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,6 +47,11 @@ jobs:
           go-version: "1.22"
           cache-dependency-path: go/go.sum
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
       - name: Install dependencies
         run: pnpm install
 
@@ -65,3 +70,10 @@ jobs:
 
       - name: Build
         run: pnpm build
+
+      - name: .NET build + test
+        run: |
+          dotnet restore SmooAI.Logger.sln
+          dotnet build SmooAI.Logger.sln -c Release --no-restore
+          dotnet test SmooAI.Logger.sln -c Release --no-build --nologo
+        working-directory: dotnet

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,50 @@
+name: Publish NuGet
+
+on:
+  push:
+    tags:
+      - "dotnet-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: dotnet
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Restore
+        run: dotnet restore SmooAI.Logger.sln
+
+      - name: Build
+        run: dotnet build SmooAI.Logger.sln -c Release --no-restore
+
+      - name: Test
+        run: dotnet test SmooAI.Logger.sln -c Release --no-build --nologo
+
+      - name: Pack
+        run: dotnet pack src/SmooAI.Logger/SmooAI.Logger.csproj -c Release --no-build -o dist
+
+      - name: Push to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          dotnet nuget push "dist/*.nupkg" \
+            --api-key "$NUGET_API_KEY" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg
+          path: dotnet/dist/*.nupkg

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,10 @@ python/**/__pycache__/
 # Rust build artifacts
 log-viewer/target/
 rust/logger/target/
+
+# .NET build artifacts
+dotnet/**/bin/
+dotnet/**/obj/
+dotnet/dist/
+*.nupkg
+*.snupkg

--- a/dotnet/SmooAI.Logger.sln
+++ b/dotnet/SmooAI.Logger.sln
@@ -1,0 +1,56 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmooAI.Logger", "src\SmooAI.Logger\SmooAI.Logger.csproj", "{9724E231-03C6-4F65-B635-D7E6DDC7B928}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmooAI.Logger.Tests", "tests\SmooAI.Logger.Tests\SmooAI.Logger.Tests.csproj", "{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Debug|x64.Build.0 = Debug|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Debug|x86.Build.0 = Debug|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Release|x64.ActiveCfg = Release|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Release|x64.Build.0 = Release|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Release|x86.ActiveCfg = Release|Any CPU
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928}.Release|x86.Build.0 = Release|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Debug|x64.Build.0 = Debug|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Release|x64.ActiveCfg = Release|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Release|x64.Build.0 = Release|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{9724E231-03C6-4F65-B635-D7E6DDC7B928} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{CB95589C-5FF4-4E24-9391-29BC7FC72BCA} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+	EndGlobalSection
+EndGlobal

--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "8.0.100",
+        "rollForward": "latestMajor",
+        "allowPrerelease": false
+    }
+}

--- a/dotnet/src/SmooAI.Logger/Level.cs
+++ b/dotnet/src/SmooAI.Logger/Level.cs
@@ -1,0 +1,57 @@
+namespace SmooAI.Logger;
+
+/// <summary>
+/// SmooAI log levels. Codes match the TS port (trace=10, debug=20, info=30, warn=40, error=50, fatal=60).
+/// </summary>
+public enum Level
+{
+    Trace = 10,
+    Debug = 20,
+    Info = 30,
+    Warn = 40,
+    Error = 50,
+    Fatal = 60,
+}
+
+internal static class LevelExtensions
+{
+    public static string ToWireString(this Level level) => level switch
+    {
+        Level.Trace => "trace",
+        Level.Debug => "debug",
+        Level.Info => "info",
+        Level.Warn => "warn",
+        Level.Error => "error",
+        Level.Fatal => "fatal",
+        _ => "info",
+    };
+
+    public static Microsoft.Extensions.Logging.LogLevel ToMsLogLevel(this Level level) => level switch
+    {
+        Level.Trace => Microsoft.Extensions.Logging.LogLevel.Trace,
+        Level.Debug => Microsoft.Extensions.Logging.LogLevel.Debug,
+        Level.Info => Microsoft.Extensions.Logging.LogLevel.Information,
+        Level.Warn => Microsoft.Extensions.Logging.LogLevel.Warning,
+        Level.Error => Microsoft.Extensions.Logging.LogLevel.Error,
+        Level.Fatal => Microsoft.Extensions.Logging.LogLevel.Critical,
+        _ => Microsoft.Extensions.Logging.LogLevel.Information,
+    };
+
+    public static Level FromString(string? value, Level fallback = Level.Info)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+        return value.Trim().ToLowerInvariant() switch
+        {
+            "trace" => Level.Trace,
+            "debug" => Level.Debug,
+            "info" or "information" => Level.Info,
+            "warn" or "warning" => Level.Warn,
+            "error" => Level.Error,
+            "fatal" or "critical" => Level.Fatal,
+            _ => fallback,
+        };
+    }
+}

--- a/dotnet/src/SmooAI.Logger/LogContext.cs
+++ b/dotnet/src/SmooAI.Logger/LogContext.cs
@@ -1,0 +1,83 @@
+using System.Text.Json.Serialization;
+
+namespace SmooAI.Logger;
+
+/// <summary>
+/// Well-known context keys emitted in structured log output. Mirrors the TS
+/// ContextKey enum so JSON shape is wire-compatible across language ports.
+/// </summary>
+public static class ContextKey
+{
+    public const string Level = "level";
+    public const string LogLevel = "LogLevel";
+    public const string Time = "time";
+    public const string Message = "msg";
+    public const string ErrorDetails = "errorDetails";
+
+    public const string Name = "name";
+    public const string CorrelationId = "correlationId";
+    public const string User = "user";
+    public const string Http = "http";
+    public const string Context = "context";
+
+    public const string RequestId = "requestId";
+    public const string Duration = "duration";
+    public const string TraceId = "traceId";
+    public const string Error = "error";
+    public const string Namespace = "namespace";
+    public const string Service = "service";
+}
+
+/// <summary>
+/// User context captured on the logger. Fields mirror the TS User type.
+/// </summary>
+public sealed class SmooUser
+{
+    [JsonPropertyName("id")] public string? Id { get; set; }
+    [JsonPropertyName("email")] public string? Email { get; set; }
+    [JsonPropertyName("phone")] public string? Phone { get; set; }
+    [JsonPropertyName("role")] public string? Role { get; set; }
+    [JsonPropertyName("fullName")] public string? FullName { get; set; }
+    [JsonPropertyName("firstName")] public string? FirstName { get; set; }
+    [JsonPropertyName("lastName")] public string? LastName { get; set; }
+    [JsonPropertyName("context")] public object? Context { get; set; }
+}
+
+/// <summary>
+/// HTTP request context.
+/// </summary>
+public sealed class SmooHttpRequest
+{
+    [JsonPropertyName("protocol")] public string? Protocol { get; set; }
+    [JsonPropertyName("hostname")] public string? Hostname { get; set; }
+    [JsonPropertyName("path")] public string? Path { get; set; }
+    [JsonPropertyName("method")] public string? Method { get; set; }
+    [JsonPropertyName("queryString")] public string? QueryString { get; set; }
+    [JsonPropertyName("sourceIp")] public string? SourceIp { get; set; }
+    [JsonPropertyName("userAgent")] public string? UserAgent { get; set; }
+    [JsonPropertyName("headers")] public IReadOnlyDictionary<string, string>? Headers { get; set; }
+    [JsonPropertyName("body")] public object? Body { get; set; }
+}
+
+/// <summary>
+/// HTTP response context.
+/// </summary>
+public sealed class SmooHttpResponse
+{
+    [JsonPropertyName("statusCode")] public int? StatusCode { get; set; }
+    [JsonPropertyName("headers")] public IReadOnlyDictionary<string, string>? Headers { get; set; }
+    [JsonPropertyName("body")] public object? Body { get; set; }
+}
+
+/// <summary>
+/// Telemetry fields merged into the base context via <see cref="SmooLogger.AddTelemetryFields"/>.
+/// </summary>
+public sealed class TelemetryFields
+{
+    public string? RequestId { get; set; }
+    public double? Duration { get; set; }
+    public string? TraceId { get; set; }
+    public string? Namespace { get; set; }
+    public string? Service { get; set; }
+    public string? Error { get; set; }
+}

--- a/dotnet/src/SmooAI.Logger/README.md
+++ b/dotnet/src/SmooAI.Logger/README.md
@@ -1,0 +1,55 @@
+# SmooAI.Logger
+
+Structured, contextual logger for AWS and .NET server environments. .NET port of `@smooai/logger`.
+
+Captures execution context (correlation IDs, HTTP request/response, user, telemetry) and emits JSON lines wire-compatible with the TypeScript, Go, Rust, and Python ports.
+
+## Install
+
+```bash
+dotnet add package SmooAI.Logger
+```
+
+## Quick start
+
+```csharp
+using SmooAI.Logger;
+
+var logger = SmooLogger.Create<MyService>(opts =>
+{
+    opts.InitialContext = new Dictionary<string, object?>
+    {
+        ["service"] = "api",
+        ["stage"] = "production",
+    };
+});
+
+logger.LogInfo("Order placed", new { orderId = "ord_123", userId = "u_456" });
+
+using (logger.BeginScope(new Dictionary<string, object?> { ["requestId"] = "req_789" }))
+{
+    logger.LogWarning("Retrying upstream call");
+}
+```
+
+## Forwarding to `Microsoft.Extensions.Logging`
+
+Wire the SmooLogger to an upstream `ILogger` (e.g. Serilog, AWS.Logger) — the structured entry is forwarded as a scope so downstream sinks receive every field.
+
+```csharp
+var factory = LoggerFactory.Create(b => b.AddSerilog());
+var smoo = new SmooLogger(new SmooLoggerOptions
+{
+    Name = "api",
+    ForwardTo = factory.CreateLogger("SmooAI.Logger"),
+});
+```
+
+## Environment
+
+- `LOG_LEVEL` — `trace` | `debug` | `info` | `warn` | `error` | `fatal` (default `info`)
+- `IS_LOCAL`, `SST_DEV`, `GITHUB_ACTIONS` — enable pretty-print mode by default
+
+## License
+
+MIT

--- a/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
+++ b/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>SmooAI.Logger</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>SmooAI</Authors>
+    <Company>SmooAI</Company>
+    <Description>Contextual structured logger for AWS and server environments. .NET port of @smooai/logger — wraps Microsoft.Extensions.Logging.ILogger with correlation IDs, HTTP request/response context, user context, and structured JSON output.</Description>
+    <PackageTags>logging;structured-logging;aws;cloudwatch;smooai</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/SmooAI/logger</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/SmooAI/logger</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/src/SmooAI.Logger/SmooLogger.cs
+++ b/dotnet/src/SmooAI.Logger/SmooLogger.cs
@@ -1,0 +1,528 @@
+using System.Collections;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace SmooAI.Logger;
+
+/// <summary>
+/// Structured, contextual logger. .NET port of the TS <c>@smooai/logger</c> base Logger.
+///
+/// Thread-safety: all public mutators lock on an internal gate; <c>Log*</c> calls take a
+/// snapshot of the context under the lock, so concurrent logging is safe.
+/// </summary>
+public class SmooLogger
+{
+    private static readonly JsonSerializerOptions CompactJson = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    private static readonly JsonSerializerOptions PrettyJson = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true,
+        Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
+    private readonly object _gate = new();
+    private readonly Dictionary<string, object?> _context = new(StringComparer.Ordinal);
+    private readonly TextWriter _output;
+    private readonly ILogger? _forwardTo;
+    private readonly bool _prettyPrint;
+    private string _name;
+    private Level _level;
+
+    /// <summary>Logger name, emitted as <c>name</c> on every entry.</summary>
+    public string Name
+    {
+        get { lock (_gate) { return _name; } }
+        set { lock (_gate) { _name = value; } }
+    }
+
+    /// <summary>Minimum log level.</summary>
+    public Level MinLevel
+    {
+        get { lock (_gate) { return _level; } }
+        set { lock (_gate) { _level = value; } }
+    }
+
+    /// <summary>Snapshot of the current base context.</summary>
+    public IReadOnlyDictionary<string, object?> Context
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return new Dictionary<string, object?>(_context, StringComparer.Ordinal);
+            }
+        }
+    }
+
+    public SmooLogger() : this(new SmooLoggerOptions()) { }
+
+    public SmooLogger(SmooLoggerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        _name = options.Name;
+        _level = options.Level ?? LevelExtensions.FromString(Environment.GetEnvironmentVariable("LOG_LEVEL"));
+        _output = options.Output ?? Console.Out;
+        _forwardTo = options.ForwardTo;
+        _prettyPrint = options.PrettyPrint ?? IsLocalEnv();
+
+        var correlationId = Guid.NewGuid().ToString();
+        _context[ContextKey.CorrelationId] = correlationId;
+        _context[ContextKey.RequestId] = correlationId;
+        _context[ContextKey.TraceId] = correlationId;
+
+        if (options.InitialContext != null)
+        {
+            foreach (var kv in options.InitialContext)
+            {
+                _context[kv.Key] = kv.Value;
+            }
+            if (options.InitialContext.TryGetValue(ContextKey.CorrelationId, out var cid) && cid is string cidStr && !string.IsNullOrEmpty(cidStr))
+            {
+                SetCorrelationIdUnlocked(cidStr);
+            }
+        }
+    }
+
+    /// <summary>Create a logger for a specific type, using the type name as the logger name.</summary>
+    public static SmooLogger Create<T>(Action<SmooLoggerOptions>? configure = null)
+    {
+        var opts = new SmooLoggerOptions { Name = typeof(T).Name };
+        configure?.Invoke(opts);
+        return new SmooLogger(opts);
+    }
+
+    // ------------- Context mutators -------------
+
+    public object? GetBaseContextKey(string key)
+    {
+        lock (_gate)
+        {
+            return _context.TryGetValue(key, out var v) ? v : null;
+        }
+    }
+
+    public void AddBaseContextKey(string key, object? value)
+    {
+        lock (_gate)
+        {
+            _context[key] = value;
+        }
+    }
+
+    /// <summary>Reset the base context and generate a fresh correlation ID.</summary>
+    public void ResetContext()
+    {
+        lock (_gate)
+        {
+            _context.Clear();
+            SetCorrelationIdUnlocked(Guid.NewGuid().ToString());
+        }
+    }
+
+    /// <summary>
+    /// Merge a dictionary into <c>context.context</c> (nested). Keys that already exist
+    /// under the nested <c>context</c> bag are overwritten.
+    /// </summary>
+    public void AddContext(IDictionary<string, object?> ctx)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+        lock (_gate)
+        {
+            var nested = _context.TryGetValue(ContextKey.Context, out var existing) && existing is IDictionary<string, object?> dict
+                ? new Dictionary<string, object?>(dict, StringComparer.Ordinal)
+                : new Dictionary<string, object?>(StringComparer.Ordinal);
+
+            foreach (var kv in ctx)
+            {
+                nested[kv.Key] = kv.Value;
+            }
+            _context[ContextKey.Context] = nested;
+        }
+    }
+
+    /// <summary>Merge a dictionary into the top-level base context.</summary>
+    public void AddBaseContext(IDictionary<string, object?> ctx)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+        lock (_gate)
+        {
+            foreach (var kv in ctx)
+            {
+                _context[kv.Key] = kv.Value;
+            }
+        }
+    }
+
+    /// <summary>Current correlation ID.</summary>
+    public string? CorrelationId()
+    {
+        return GetBaseContextKey(ContextKey.CorrelationId) as string;
+    }
+
+    /// <summary>Generate + set a fresh correlation ID (also updates requestId + traceId).</summary>
+    public void ResetCorrelationId()
+    {
+        SetCorrelationId(Guid.NewGuid().ToString());
+    }
+
+    /// <summary>Set correlation ID + request ID + trace ID to the same value.</summary>
+    public void SetCorrelationId(string correlationId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(correlationId);
+        lock (_gate)
+        {
+            SetCorrelationIdUnlocked(correlationId);
+        }
+    }
+
+    private void SetCorrelationIdUnlocked(string correlationId)
+    {
+        _context[ContextKey.CorrelationId] = correlationId;
+        _context[ContextKey.RequestId] = correlationId;
+        _context[ContextKey.TraceId] = correlationId;
+    }
+
+    /// <summary>Add user context.</summary>
+    public void AddUserContext(SmooUser? user)
+    {
+        if (user == null) return;
+        AddBaseContext(new Dictionary<string, object?> { [ContextKey.User] = user });
+    }
+
+    /// <summary>Set the <c>namespace</c> field.</summary>
+    public void SetNamespace(string value) => AddBaseContextKey(ContextKey.Namespace, value);
+
+    /// <summary>Add an HTTP request to the <c>http.request</c> sub-context.</summary>
+    public void AddHttpRequest(SmooHttpRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        lock (_gate)
+        {
+            var http = GetHttpBagUnlocked();
+            http["request"] = request;
+            _context[ContextKey.Http] = http;
+        }
+    }
+
+    /// <summary>Add an HTTP response to the <c>http.response</c> sub-context.</summary>
+    public void AddHttpResponse(SmooHttpResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        lock (_gate)
+        {
+            var http = GetHttpBagUnlocked();
+            http["response"] = response;
+            _context[ContextKey.Http] = http;
+        }
+    }
+
+    /// <summary>Merge telemetry fields into the base context.</summary>
+    public void AddTelemetryFields(TelemetryFields fields)
+    {
+        ArgumentNullException.ThrowIfNull(fields);
+        var bag = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (fields.RequestId != null) bag[ContextKey.RequestId] = fields.RequestId;
+        if (fields.Duration != null) bag[ContextKey.Duration] = fields.Duration;
+        if (fields.TraceId != null) bag[ContextKey.TraceId] = fields.TraceId;
+        if (fields.Namespace != null) bag[ContextKey.Namespace] = fields.Namespace;
+        if (fields.Service != null) bag[ContextKey.Service] = fields.Service;
+        if (fields.Error != null) bag[ContextKey.Error] = fields.Error;
+        AddBaseContext(bag);
+    }
+
+    /// <summary>
+    /// Push a scope with additional context. The returned <see cref="IDisposable"/> reverts
+    /// the context to its prior state when disposed. Equivalent to ILogger.BeginScope.
+    /// </summary>
+    public IDisposable BeginScope(IDictionary<string, object?> scopeContext)
+    {
+        ArgumentNullException.ThrowIfNull(scopeContext);
+        Dictionary<string, object?> snapshot;
+        lock (_gate)
+        {
+            snapshot = new Dictionary<string, object?>(_context, StringComparer.Ordinal);
+            foreach (var kv in scopeContext)
+            {
+                _context[kv.Key] = kv.Value;
+            }
+        }
+        return new ScopeReverter(this, snapshot);
+    }
+
+    private sealed class ScopeReverter : IDisposable
+    {
+        private readonly SmooLogger _owner;
+        private readonly Dictionary<string, object?> _snapshot;
+        private bool _disposed;
+
+        public ScopeReverter(SmooLogger owner, Dictionary<string, object?> snapshot)
+        {
+            _owner = owner;
+            _snapshot = snapshot;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            lock (_owner._gate)
+            {
+                _owner._context.Clear();
+                foreach (var kv in _snapshot)
+                {
+                    _owner._context[kv.Key] = kv.Value;
+                }
+            }
+        }
+    }
+
+    // ------------- Logging -------------
+
+    public bool IsEnabled(Level level) => level >= MinLevel;
+
+    public void LogTrace(string message, object? data = null, Exception? error = null)
+        => Emit(Level.Trace, message, data, error);
+
+    public void LogDebug(string message, object? data = null, Exception? error = null)
+        => Emit(Level.Debug, message, data, error);
+
+    public void LogInfo(string message, object? data = null, Exception? error = null)
+        => Emit(Level.Info, message, data, error);
+
+    public void LogWarning(string message, object? data = null, Exception? error = null)
+        => Emit(Level.Warn, message, data, error);
+
+    public void LogError(string message, object? data = null, Exception? error = null)
+        => Emit(Level.Error, message, data, error);
+
+    public void LogFatal(string message, object? data = null, Exception? error = null)
+        => Emit(Level.Fatal, message, data, error);
+
+    /// <summary>Primary entry point — emit a structured log at the given level.</summary>
+    public void Log(Level level, string message, object? data = null, Exception? error = null)
+        => Emit(level, message, data, error);
+
+    private void Emit(Level level, string message, object? data, Exception? error)
+    {
+        if (!IsEnabled(level))
+        {
+            return;
+        }
+
+        Dictionary<string, object?> entry;
+        lock (_gate)
+        {
+            entry = new Dictionary<string, object?>(_context, StringComparer.Ordinal);
+        }
+
+        if (!string.IsNullOrEmpty(message))
+        {
+            entry[ContextKey.Message] = message;
+        }
+
+        if (data != null)
+        {
+            MergeDataIntoEntry(entry, data);
+        }
+
+        if (error != null)
+        {
+            ApplyError(entry, error);
+            if (!entry.ContainsKey(ContextKey.Message) && entry.TryGetValue(ContextKey.Error, out var errMsg))
+            {
+                entry[ContextKey.Message] = errMsg;
+            }
+        }
+
+        entry[ContextKey.Level] = (int)level;
+        entry[ContextKey.LogLevel] = level.ToWireString();
+        entry[ContextKey.Time] = DateTimeOffset.UtcNow.ToString("O");
+        entry[ContextKey.Name] = _name;
+
+        WriteEntry(entry, level, message, error);
+    }
+
+    private static void ApplyError(Dictionary<string, object?> entry, Exception error)
+    {
+        if (entry.TryGetValue(ContextKey.Error, out var existing) && existing is string prev && !string.IsNullOrEmpty(prev))
+        {
+            entry[ContextKey.Error] = $"{prev}; {error.Message}";
+        }
+        else
+        {
+            entry[ContextKey.Error] = error.Message;
+        }
+
+        var details = entry.TryGetValue(ContextKey.ErrorDetails, out var d) && d is List<object> existingList
+            ? existingList
+            : new List<object>();
+        details.Add(SerializeException(error));
+        entry[ContextKey.ErrorDetails] = details;
+    }
+
+    private static object SerializeException(Exception ex)
+    {
+        var dict = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["name"] = ex.GetType().Name,
+            ["message"] = ex.Message,
+            ["stack"] = ex.StackTrace,
+        };
+        if (ex.InnerException != null)
+        {
+            dict["cause"] = SerializeException(ex.InnerException);
+        }
+        return dict;
+    }
+
+    private static void MergeDataIntoEntry(Dictionary<string, object?> entry, object data)
+    {
+        // If data is a dictionary, merge into context.context.
+        IDictionary<string, object?> incoming;
+        if (data is IDictionary<string, object?> dict)
+        {
+            incoming = dict;
+        }
+        else if (data is IDictionary nonGeneric)
+        {
+            incoming = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (DictionaryEntry de in nonGeneric)
+            {
+                incoming[de.Key.ToString() ?? ""] = de.Value;
+            }
+        }
+        else
+        {
+            // Reflect public, readable properties (supports anonymous objects + records).
+            incoming = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var prop in data.GetType().GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+            {
+                if (!prop.CanRead || prop.GetIndexParameters().Length > 0)
+                {
+                    continue;
+                }
+                incoming[prop.Name] = prop.GetValue(data);
+            }
+        }
+
+        foreach (var kv in incoming)
+        {
+            if (kv.Value is Exception ex)
+            {
+                ApplyError(entry, ex);
+            }
+        }
+
+        var nested = entry.TryGetValue(ContextKey.Context, out var existing) && existing is IDictionary<string, object?> existingDict
+            ? new Dictionary<string, object?>(existingDict, StringComparer.Ordinal)
+            : new Dictionary<string, object?>(StringComparer.Ordinal);
+
+        foreach (var kv in incoming)
+        {
+            nested[kv.Key] = kv.Value;
+        }
+        entry[ContextKey.Context] = nested;
+    }
+
+    private void WriteEntry(Dictionary<string, object?> entry, Level level, string message, Exception? error)
+    {
+        var opts = _prettyPrint ? PrettyJson : CompactJson;
+        string json;
+        try
+        {
+            json = JsonSerializer.Serialize(entry, opts);
+        }
+        catch (Exception serializeEx)
+        {
+            // Fallback: strip the potentially-bad context and retry.
+            var safe = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                [ContextKey.Level] = entry[ContextKey.Level],
+                [ContextKey.LogLevel] = entry[ContextKey.LogLevel],
+                [ContextKey.Time] = entry[ContextKey.Time],
+                [ContextKey.Name] = entry[ContextKey.Name],
+                [ContextKey.Message] = message,
+                [ContextKey.Error] = serializeEx.Message,
+            };
+            json = JsonSerializer.Serialize(safe, opts);
+        }
+
+        var sb = new StringBuilder();
+        sb.Append(json);
+        sb.Append('\n');
+        if (_prettyPrint)
+        {
+            // 3x dashed separators — matches TS output so log-viewer regexes keep working.
+            const string bar = "----------------------------------------------------------------------------------------------------";
+            sb.Append(bar).Append('\n');
+            sb.Append(bar).Append('\n');
+            sb.Append(bar).Append('\n');
+        }
+
+        var payload = sb.ToString();
+        lock (_output)
+        {
+            _output.Write(payload);
+            _output.Flush();
+        }
+
+        if (_forwardTo != null && _forwardTo.IsEnabled(level.ToMsLogLevel()))
+        {
+            _forwardTo.Log(
+                level.ToMsLogLevel(),
+                new EventId((int)level, level.ToWireString()),
+                new StructuredLogState(entry, message),
+                error,
+                static (state, _) => state.Message);
+        }
+    }
+
+    private Dictionary<string, object?> GetHttpBagUnlocked()
+    {
+        if (_context.TryGetValue(ContextKey.Http, out var existing) && existing is IDictionary<string, object?> dict)
+        {
+            return new Dictionary<string, object?>(dict, StringComparer.Ordinal);
+        }
+        return new Dictionary<string, object?>(StringComparer.Ordinal);
+    }
+
+    private static bool IsLocalEnv()
+    {
+        return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IS_LOCAL"))
+            || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SST_DEV"))
+            || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
+    }
+
+    /// <summary>
+    /// Log state passed to the forwarded ILogger. Exposes the structured entry via
+    /// <see cref="IReadOnlyList{KeyValuePair}"/> so Serilog / AWS.Logger can see each field.
+    /// </summary>
+    private sealed class StructuredLogState : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        private readonly List<KeyValuePair<string, object?>> _fields;
+
+        public StructuredLogState(IDictionary<string, object?> entry, string message)
+        {
+            Message = message;
+            _fields = new List<KeyValuePair<string, object?>>(entry.Count + 1);
+            foreach (var kv in entry)
+            {
+                _fields.Add(new KeyValuePair<string, object?>(kv.Key, kv.Value));
+            }
+            _fields.Add(new KeyValuePair<string, object?>("{OriginalFormat}", message));
+        }
+
+        public string Message { get; }
+        public int Count => _fields.Count;
+        public KeyValuePair<string, object?> this[int index] => _fields[index];
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => _fields.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/dotnet/src/SmooAI.Logger/SmooLoggerOptions.cs
+++ b/dotnet/src/SmooAI.Logger/SmooLoggerOptions.cs
@@ -1,0 +1,32 @@
+namespace SmooAI.Logger;
+
+/// <summary>
+/// Options for constructing a <see cref="SmooLogger"/>. Mirrors the TS Logger constructor options.
+/// </summary>
+public sealed class SmooLoggerOptions
+{
+    /// <summary>Logger name, emitted as <c>name</c> on every entry.</summary>
+    public string Name { get; set; } = "Logger";
+
+    /// <summary>Minimum level to emit. Defaults to <c>LOG_LEVEL</c> env var, falling back to Info.</summary>
+    public Level? Level { get; set; }
+
+    /// <summary>
+    /// Initial base context merged into the logger before any log call. Keys under this dictionary
+    /// appear at the top level of every structured entry.
+    /// </summary>
+    public IDictionary<string, object?>? InitialContext { get; set; }
+
+    /// <summary>Pretty-print output (multi-line indented JSON). Defaults true locally, false in deployed stages.</summary>
+    public bool? PrettyPrint { get; set; }
+
+    /// <summary>Optional <see cref="TextWriter"/> to write structured output to. Defaults to <see cref="Console.Out"/>.</summary>
+    public TextWriter? Output { get; set; }
+
+    /// <summary>
+    /// Optional upstream <see cref="Microsoft.Extensions.Logging.ILogger"/> to forward structured entries to.
+    /// When set, SmooLogger also calls <c>logger.Log(...)</c> with the structured scope so Serilog / CloudWatch
+    /// sinks wired through <c>ILoggerFactory</c> continue to receive the entry.
+    /// </summary>
+    public Microsoft.Extensions.Logging.ILogger? ForwardTo { get; set; }
+}

--- a/dotnet/tests/SmooAI.Logger.Tests/SmooAI.Logger.Tests.csproj
+++ b/dotnet/tests/SmooAI.Logger.Tests/SmooAI.Logger.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SmooAI.Logger\SmooAI.Logger.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/tests/SmooAI.Logger.Tests/SmooLoggerTests.cs
+++ b/dotnet/tests/SmooAI.Logger.Tests/SmooLoggerTests.cs
@@ -1,0 +1,318 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using SmooAI.Logger;
+
+namespace SmooAI.Logger.Tests;
+
+public class SmooLoggerTests
+{
+    private static (SmooLogger Logger, StringWriter Out) Build(Action<SmooLoggerOptions>? configure = null)
+    {
+        var writer = new StringWriter();
+        var opts = new SmooLoggerOptions { Output = writer, PrettyPrint = false };
+        configure?.Invoke(opts);
+        return (new SmooLogger(opts), writer);
+    }
+
+    private static JsonElement ParseSingle(string captured)
+    {
+        // Compact output: one JSON object per line. Grab the first line.
+        var line = captured.Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        return JsonDocument.Parse(line).RootElement;
+    }
+
+    [Fact]
+    public void Emits_Required_Fields()
+    {
+        var (logger, writer) = Build(o => o.Name = "test");
+        logger.LogInfo("hello world");
+        var entry = ParseSingle(writer.ToString());
+
+        Assert.Equal("hello world", entry.GetProperty("msg").GetString());
+        Assert.Equal("info", entry.GetProperty("LogLevel").GetString());
+        Assert.Equal(30, entry.GetProperty("level").GetInt32());
+        Assert.Equal("test", entry.GetProperty("name").GetString());
+        Assert.True(entry.TryGetProperty("time", out _));
+        Assert.True(entry.TryGetProperty("correlationId", out _));
+        Assert.True(entry.TryGetProperty("requestId", out _));
+        Assert.True(entry.TryGetProperty("traceId", out _));
+    }
+
+    [Fact]
+    public void Level_Filter_Suppresses_Below_Minimum()
+    {
+        var (logger, writer) = Build(o => o.Level = Level.Warn);
+        logger.LogInfo("ignored");
+        logger.LogWarning("emitted");
+
+        var lines = writer.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Single(lines);
+        Assert.Contains("emitted", lines[0]);
+    }
+
+    [Fact]
+    public void SetCorrelationId_Updates_All_Tracking_Ids()
+    {
+        var (logger, writer) = Build();
+        logger.SetCorrelationId("corr-xyz");
+        logger.LogInfo("msg");
+        var entry = ParseSingle(writer.ToString());
+
+        Assert.Equal("corr-xyz", entry.GetProperty("correlationId").GetString());
+        Assert.Equal("corr-xyz", entry.GetProperty("requestId").GetString());
+        Assert.Equal("corr-xyz", entry.GetProperty("traceId").GetString());
+    }
+
+    [Fact]
+    public void ResetContext_Clears_And_Generates_New_CorrelationId()
+    {
+        var (logger, _) = Build();
+        var original = logger.CorrelationId();
+
+        logger.AddBaseContextKey("service", "api");
+        logger.ResetContext();
+
+        Assert.Null(logger.GetBaseContextKey("service"));
+        Assert.NotNull(logger.CorrelationId());
+        Assert.NotEqual(original, logger.CorrelationId());
+    }
+
+    [Fact]
+    public void AddContext_Merges_Into_Nested_Context_Bag()
+    {
+        var (logger, writer) = Build();
+        logger.AddContext(new Dictionary<string, object?> { ["orderId"] = "ord_1" });
+        logger.LogInfo("msg");
+
+        var entry = ParseSingle(writer.ToString());
+        var ctx = entry.GetProperty("context");
+        Assert.Equal("ord_1", ctx.GetProperty("orderId").GetString());
+    }
+
+    [Fact]
+    public void AddBaseContext_Merges_Into_Top_Level()
+    {
+        var (logger, writer) = Build();
+        logger.AddBaseContext(new Dictionary<string, object?> { ["service"] = "api" });
+        logger.LogInfo("msg");
+
+        var entry = ParseSingle(writer.ToString());
+        Assert.Equal("api", entry.GetProperty("service").GetString());
+    }
+
+    [Fact]
+    public void Data_Anonymous_Object_Becomes_Nested_Context()
+    {
+        var (logger, writer) = Build();
+        logger.LogInfo("placed", new { orderId = "ord_42", userId = "u_7" });
+
+        var entry = ParseSingle(writer.ToString());
+        var ctx = entry.GetProperty("context");
+        Assert.Equal("ord_42", ctx.GetProperty("orderId").GetString());
+        Assert.Equal("u_7", ctx.GetProperty("userId").GetString());
+    }
+
+    [Fact]
+    public void Data_Dictionary_Merges_Into_Nested_Context()
+    {
+        var (logger, writer) = Build();
+        var data = new Dictionary<string, object?> { ["foo"] = "bar" };
+        logger.LogInfo("msg", data);
+
+        var entry = ParseSingle(writer.ToString());
+        Assert.Equal("bar", entry.GetProperty("context").GetProperty("foo").GetString());
+    }
+
+    [Fact]
+    public void Exception_Parameter_Populates_Error_And_ErrorDetails()
+    {
+        var (logger, writer) = Build();
+        var ex = new InvalidOperationException("boom");
+        logger.LogError("something failed", error: ex);
+
+        var entry = ParseSingle(writer.ToString());
+        Assert.Equal("boom", entry.GetProperty("error").GetString());
+        var details = entry.GetProperty("errorDetails");
+        Assert.Equal(1, details.GetArrayLength());
+        Assert.Equal("InvalidOperationException", details[0].GetProperty("name").GetString());
+        Assert.Equal("boom", details[0].GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public void Exception_In_Data_Is_Detected()
+    {
+        var (logger, writer) = Build();
+        logger.LogError("failed", new { err = new ArgumentNullException("paramX") });
+
+        var entry = ParseSingle(writer.ToString());
+        Assert.True(entry.TryGetProperty("error", out _));
+        Assert.True(entry.TryGetProperty("errorDetails", out _));
+    }
+
+    [Fact]
+    public void BeginScope_Reverts_On_Dispose()
+    {
+        var (logger, writer) = Build();
+        using (logger.BeginScope(new Dictionary<string, object?> { ["scoped"] = "yes" }))
+        {
+            logger.LogInfo("inside");
+        }
+        logger.LogInfo("outside");
+
+        var lines = writer.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var inside = JsonDocument.Parse(lines[0]).RootElement;
+        var outside = JsonDocument.Parse(lines[1]).RootElement;
+
+        Assert.Equal("yes", inside.GetProperty("scoped").GetString());
+        Assert.False(outside.TryGetProperty("scoped", out _));
+    }
+
+    [Fact]
+    public void AddUserContext_Attaches_User_Object()
+    {
+        var (logger, writer) = Build();
+        logger.AddUserContext(new SmooUser { Id = "u_1", Email = "a@b.com" });
+        logger.LogInfo("msg");
+
+        var entry = ParseSingle(writer.ToString());
+        var user = entry.GetProperty("user");
+        Assert.Equal("u_1", user.GetProperty("id").GetString());
+        Assert.Equal("a@b.com", user.GetProperty("email").GetString());
+    }
+
+    [Fact]
+    public void AddHttpRequest_Attaches_Under_http_request()
+    {
+        var (logger, writer) = Build();
+        logger.AddHttpRequest(new SmooHttpRequest { Method = "POST", Path = "/orders", Hostname = "api.example" });
+        logger.LogInfo("msg");
+
+        var entry = ParseSingle(writer.ToString());
+        var req = entry.GetProperty("http").GetProperty("request");
+        Assert.Equal("POST", req.GetProperty("method").GetString());
+        Assert.Equal("/orders", req.GetProperty("path").GetString());
+    }
+
+    [Fact]
+    public void AddHttpResponse_Preserves_Existing_Request()
+    {
+        var (logger, writer) = Build();
+        logger.AddHttpRequest(new SmooHttpRequest { Method = "GET", Path = "/x" });
+        logger.AddHttpResponse(new SmooHttpResponse { StatusCode = 201 });
+        logger.LogInfo("msg");
+
+        var http = ParseSingle(writer.ToString()).GetProperty("http");
+        Assert.Equal("GET", http.GetProperty("request").GetProperty("method").GetString());
+        Assert.Equal(201, http.GetProperty("response").GetProperty("statusCode").GetInt32());
+    }
+
+    [Fact]
+    public void AddTelemetryFields_Merges_Top_Level()
+    {
+        var (logger, writer) = Build();
+        logger.AddTelemetryFields(new TelemetryFields { Service = "billing", Duration = 42.5, Namespace = "POST /charge" });
+        logger.LogInfo("msg");
+
+        var entry = ParseSingle(writer.ToString());
+        Assert.Equal("billing", entry.GetProperty("service").GetString());
+        Assert.Equal(42.5, entry.GetProperty("duration").GetDouble());
+        Assert.Equal("POST /charge", entry.GetProperty("namespace").GetString());
+    }
+
+    [Fact]
+    public void Create_Generic_Names_Logger_After_Type()
+    {
+        var logger = SmooLogger.Create<SmooLoggerTests>();
+        Assert.Equal(nameof(SmooLoggerTests), logger.Name);
+    }
+
+    [Fact]
+    public void InitialContext_Sets_CorrelationId()
+    {
+        var writer = new StringWriter();
+        var logger = new SmooLogger(new SmooLoggerOptions
+        {
+            Output = writer,
+            PrettyPrint = false,
+            InitialContext = new Dictionary<string, object?> { ["correlationId"] = "cid-from-init" },
+        });
+        logger.LogInfo("msg");
+
+        var entry = ParseSingle(writer.ToString());
+        Assert.Equal("cid-from-init", entry.GetProperty("correlationId").GetString());
+        Assert.Equal("cid-from-init", entry.GetProperty("requestId").GetString());
+        Assert.Equal("cid-from-init", entry.GetProperty("traceId").GetString());
+    }
+
+    [Fact]
+    public void ForwardTo_Receives_Structured_Entry()
+    {
+        var captured = new List<(LogLevel Level, string Message, List<KeyValuePair<string, object?>> Fields)>();
+        var forward = new CaptureLogger(captured);
+        var writer = new StringWriter();
+
+        var logger = new SmooLogger(new SmooLoggerOptions
+        {
+            Output = writer,
+            PrettyPrint = false,
+            ForwardTo = forward,
+        });
+        logger.LogInfo("forwarded", new { orderId = "ord_99" });
+
+        Assert.Single(captured);
+        var (lvl, msg, fields) = captured[0];
+        Assert.Equal(LogLevel.Information, lvl);
+        Assert.Equal("forwarded", msg);
+        Assert.Contains(fields, f => f.Key == "msg" && f.Value as string == "forwarded");
+        Assert.Contains(fields, f => f.Key == "name");
+    }
+
+    [Fact]
+    public void IsEnabled_Respects_Min_Level()
+    {
+        var (logger, _) = Build(o => o.Level = Level.Error);
+        Assert.False(logger.IsEnabled(Level.Info));
+        Assert.True(logger.IsEnabled(Level.Error));
+        Assert.True(logger.IsEnabled(Level.Fatal));
+    }
+
+    [Fact]
+    public void Concurrent_Logging_Does_Not_Throw()
+    {
+        var (logger, writer) = Build();
+        var tasks = Enumerable.Range(0, 50).Select(i =>
+            Task.Run(() => logger.LogInfo($"msg-{i}", new { i }))).ToArray();
+        Task.WaitAll(tasks);
+
+        var lines = writer.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(50, lines.Length);
+        foreach (var line in lines)
+        {
+            JsonDocument.Parse(line); // must be valid JSON
+        }
+    }
+
+    private sealed class CaptureLogger : ILogger
+    {
+        private readonly List<(LogLevel Level, string Message, List<KeyValuePair<string, object?>> Fields)> _captured;
+
+        public CaptureLogger(List<(LogLevel, string, List<KeyValuePair<string, object?>>)> captured)
+        {
+            _captured = captured;
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            var fields = new List<KeyValuePair<string, object?>>();
+            if (state is IEnumerable<KeyValuePair<string, object?>> enumerable)
+            {
+                fields.AddRange(enumerable);
+            }
+            _captured.Add((logLevel, formatter(state, exception), fields));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a .NET (net8.0) port of `@smooai/logger` under `dotnet/` — `SmooAI.Logger` NuGet package
- Faithful port of the TS base Logger: correlation IDs, structured fields, BeginScope, error/telemetry/http/user context, pretty vs compact JSON output
- Forwards structured entries to any upstream `ILogger` (Serilog, AWS.Logger, etc.) when `SmooLoggerOptions.ForwardTo` is set
- Ships `.github/workflows/publish-nuget.yml` (triggered on `dotnet-v*` tag or manual dispatch) + a .NET build+test job in `pr-checks.yml`
- 20 xUnit tests cover the full behavior contract

## Test plan
- [x] `dotnet build SmooAI.Logger.sln -c Release` passes clean (0 warnings, 0 errors)
- [x] `dotnet test SmooAI.Logger.sln -c Release` — 20/20 pass locally
- [x] `dotnet pack src/SmooAI.Logger/SmooAI.Logger.csproj -c Release` produces `SmooAI.Logger.0.1.0.nupkg` + `.snupkg`
- [x] Pre-commit hook runs full TS/Python/Rust/Go/log-viewer check-all — all green
- [ ] CI (`PR Checks`) green on this PR
- [ ] After merge, tag `dotnet-v0.1.0` to trigger first NuGet publish

Jira: SMOODEV-658