### PR TITLE
SMOODEV-662: Sync SmooAI.Logger NuGet version to npm + polish NuGet README

### DIFF
--- a/.changeset/smoodev-662-dotnet-version-sync.md
+++ b/.changeset/smoodev-662-dotnet-version-sync.md
@@ -1,0 +1,5 @@
+---
+'@smooai/logger': patch
+---
+
+SMOODEV-662: Sync SmooAI.Logger NuGet version to package.json + polish NuGet README + wire NuGet publish into release workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,11 @@ jobs:
           go-version: "1.22"
           cache-dependency-path: go/go.sum
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
       - name: Install dependencies
         run: pnpm install
 
@@ -124,6 +129,34 @@ jobs:
           git tag "${TAG}"
           git push origin "${TAG}"
           echo "Go module tagged and pushed: ${TAG}"
+
+      - name: Build and test .NET
+        if: steps.changesets.outputs.published == 'true'
+        working-directory: dotnet
+        run: |
+          dotnet restore SmooAI.Logger.sln
+          dotnet build SmooAI.Logger.sln -c Release --no-restore
+          dotnet test SmooAI.Logger.sln -c Release --no-build --nologo
+
+      - name: Pack and publish SmooAI.Logger to NuGet
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Packing SmooAI.Logger ${VERSION}"
+          dotnet pack dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj \
+            --configuration Release \
+            -p:Version=${VERSION} \
+            -p:PackageVersion=${VERSION} \
+            -o dotnet/artifacts
+          for pkg in dotnet/artifacts/*.nupkg; do
+            echo "Pushing $pkg to NuGet..."
+            dotnet nuget push "$pkg" \
+              --api-key "${NUGET_API_KEY}" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          done
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
       - name: Auto-Merge Changeset PR
         run: |

--- a/dotnet/src/SmooAI.Logger/README.md
+++ b/dotnet/src/SmooAI.Logger/README.md
@@ -1,8 +1,8 @@
 # SmooAI.Logger
 
-Structured, contextual logger for AWS and .NET server environments. .NET port of `@smooai/logger`.
+**Structured, contextual logging for .NET — correlation IDs, typed request/user context, and JSON-line output that plays nicely with CloudWatch, Datadog, and anything that reads JSON.**
 
-Captures execution context (correlation IDs, HTTP request/response, user, telemetry) and emits JSON lines wire-compatible with the TypeScript, Go, Rust, and Python ports.
+.NET port of [`@smooai/logger`](https://github.com/SmooAI/logger). Wire-compatible with the TypeScript, Python, Go, and Rust ports — the same JSON shape, the same fields, the same correlation semantics. Wraps `Microsoft.Extensions.Logging.ILogger` so existing sinks (Serilog, AWS.Logger, `ConsoleLoggerProvider`) receive every structured field.
 
 ## Install
 
@@ -15,41 +15,89 @@ dotnet add package SmooAI.Logger
 ```csharp
 using SmooAI.Logger;
 
-var logger = SmooLogger.Create<MyService>(opts =>
+var log = new SmooLogger(new SmooLoggerOptions
 {
-    opts.InitialContext = new Dictionary<string, object?>
+    Name = "api",
+    InitialContext = new Dictionary<string, object?>
     {
-        ["service"] = "api",
-        ["stage"] = "production",
-    };
+        ["service"] = "checkout-api",
+        ["stage"]   = "production",
+    },
 });
 
-logger.LogInfo("Order placed", new { orderId = "ord_123", userId = "u_456" });
+log.LogInfo("Order placed", new { orderId = "ord_123", userId = "u_456", total = 42.00m });
+```
 
-using (logger.BeginScope(new Dictionary<string, object?> { ["requestId"] = "req_789" }))
+Output (CloudWatch-friendly JSON line):
+
+```json
 {
-    logger.LogWarning("Retrying upstream call");
+  "level": "info",
+  "name": "api",
+  "time": "2026-04-23T12:34:56.789Z",
+  "correlationId": "6b4e…",
+  "requestId": "6b4e…",
+  "service": "checkout-api",
+  "stage": "production",
+  "msg": "Order placed",
+  "orderId": "ord_123",
+  "userId": "u_456",
+  "total": 42.00
 }
 ```
 
-## Forwarding to `Microsoft.Extensions.Logging`
+## Why SmooAI.Logger?
 
-Wire the SmooLogger to an upstream `ILogger` (e.g. Serilog, AWS.Logger) — the structured entry is forwarded as a scope so downstream sinks receive every field.
+`Microsoft.Extensions.Logging` gives you levels and scopes but leaves correlation, request context, user context, and AWS-friendly JSON emission up to you. SmooAI.Logger layers those on:
+
+- **Correlation IDs out of the box** — every logger instance gets a `correlationId` / `requestId` / `traceId` at construction; propagate them across service boundaries without re-plumbing.
+- **Typed HTTP + user + AWS context** — `SetRequestContext`, `SetResponseContext`, `SetUser`, `SetLambdaContext` attach strongly-typed metadata that surfaces as first-class fields on every subsequent log line.
+- **Scoped context** — `using (log.BeginScope(new { requestId = "req_789" }))` merges context for the block; thread-safe snapshotting means concurrent `LogInfo` calls don't step on each other.
+- **Forward to any `ILogger`** — set `ForwardTo = factory.CreateLogger(...)` and your structured entry flows through the rest of your logging pipeline unchanged.
+- **Pretty in dev, JSON in prod** — auto-detects `IS_LOCAL` / `SST_DEV` / `GITHUB_ACTIONS`; force with `PrettyPrint = true/false`.
+
+## Scopes and correlation
 
 ```csharp
+using (log.BeginScope(new Dictionary<string, object?> { ["requestId"] = "req_789" }))
+{
+    log.LogWarning("Retrying upstream call", new { attempt = 2 });
+    // every log inside the scope carries requestId=req_789 on top of the base context
+}
+```
+
+## Forwarding to Microsoft.Extensions.Logging
+
+```csharp
+using Microsoft.Extensions.Logging;
+
 var factory = LoggerFactory.Create(b => b.AddSerilog());
-var smoo = new SmooLogger(new SmooLoggerOptions
+var log = new SmooLogger(new SmooLoggerOptions
 {
     Name = "api",
     ForwardTo = factory.CreateLogger("SmooAI.Logger"),
 });
+
+log.LogError("Upstream timeout", new Exception("connect timed out"),
+    new { upstream = "stripe", timeoutMs = 3000 });
 ```
+
+The SmooLogger still emits JSON to stdout **and** forwards the structured payload as a scope to Serilog — downstream sinks receive every field as a first-class property, not a string blob.
 
 ## Environment
 
-- `LOG_LEVEL` — `trace` | `debug` | `info` | `warn` | `error` | `fatal` (default `info`)
-- `IS_LOCAL`, `SST_DEV`, `GITHUB_ACTIONS` — enable pretty-print mode by default
+| Variable | Values | Default | Effect |
+|----------|--------|---------|--------|
+| `LOG_LEVEL` | `trace` `debug` `info` `warn` `error` `fatal` | `info` | Minimum level emitted |
+| `IS_LOCAL`, `SST_DEV`, `GITHUB_ACTIONS` | `"true"` | — | Enables pretty-print |
+
+## Related
+
+- [`@smooai/logger`](https://www.npmjs.com/package/@smooai/logger) — TypeScript / Node
+- [`smooai-logger`](https://crates.io/crates/smooai-logger) — Rust
+- [`smooai-logger`](https://pypi.org/project/smooai-logger/) — Python
+- [`github.com/SmooAI/logger/go`](https://github.com/SmooAI/logger/tree/main/go) — Go
 
 ## License
 
-MIT
+MIT — © SmooAI

--- a/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
+++ b/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <PackageId>SmooAI.Logger</PackageId>
-    <Version>0.1.0</Version>
+    <Version>4.1.0</Version>
     <Authors>SmooAI</Authors>
     <Company>SmooAI</Company>
     <Description>Contextual structured logger for AWS and server environments. .NET port of @smooai/logger — wraps Microsoft.Extensions.Logging.ILogger with correlation IDs, HTTP request/response context, user context, and structured JSON output.</Description>

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -75,6 +75,16 @@ const updates = [
       return content.replace(pattern, `$1${version}$3`);
     },
   },
+  {
+    path: "dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj",
+    apply(content) {
+      const pattern = /(<Version>)([^<]+)(<\/Version>)/;
+      if (!pattern.test(content)) {
+        throw new Error("<Version> element not found in dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj");
+      }
+      return content.replace(pattern, `$1${version}$3`);
+    },
+  },
 ];
 
 let touched = 0;


### PR DESCRIPTION
## Summary
- Extend `scripts/sync-versions.mjs` to update `<Version>` in `dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj` from `package.json`, so the NuGet version follows the npm version on every release.
- Rewrite the NuGet-facing README (`dotnet/src/SmooAI.Logger/README.md`) with a hero, quickstart, structured JSON output sample, scope/correlation docs, `ILogger` forwarding example, and sibling-language package links.
- Wire NuGet publish into `release.yml` (mirroring the `@smooai/file` pattern): on a published changeset, the workflow now `dotnet pack`s SmooAI.Logger at the synced version and `dotnet nuget push`es via `NUGET_API_KEY`.
- Version bumped from `0.1.0` to `4.1.0` (matches npm via sync script).

## Test plan
- [x] `node scripts/sync-versions.mjs` updates the csproj `<Version>` to match `package.json`.
- [x] `dotnet pack -p:Version=4.1.0` produces `SmooAI.Logger.4.1.0.nupkg` with `README.md` embedded.
- [ ] After merge, Changesets opens the version PR; release workflow publishes SmooAI.Logger 4.1.0 to nuget.org.

Jira: [SMOODEV-662](https://smooai.atlassian.net/browse/SMOODEV-662)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SMOODEV-662]: https://smooai.atlassian.net/browse/SMOODEV-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ