### PR TITLE
SMOODEV-666: Multi-target SmooAI.Logger to net8.0;net9.0;net10.0

### DIFF
--- a/.changeset/smoodev-666-multi-target.md
+++ b/.changeset/smoodev-666-multi-target.md
@@ -1,0 +1,5 @@
+---
+'@smooai/logger': patch
+---
+
+SMOODEV-666: Multi-target the SmooAI.Logger NuGet package to `net8.0;net9.0;net10.0` so consumers on every current .NET LTS + STS release get a native framework match in the `lib/` folder. Microsoft.Extensions.Logging.Abstractions 8.0.2 resolves cleanly on all three — no per-TFM conditionals needed.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -20,7 +20,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Restore
         run: dotnet restore SmooAI.Logger.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.x"
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Install dependencies
         run: pnpm install

--- a/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
+++ b/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Summary
- Switch `SmooAI.Logger.csproj` from `<TargetFramework>net8.0</TargetFramework>` to `<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>` so the NuGet package ships `lib/net{8,9,10}.0/SmooAI.Logger.dll` and consumers on every current .NET LTS + STS release get a native match.
- `Microsoft.Extensions.Logging.Abstractions 8.0.2` resolves cleanly on all three TFMs — no per-TFM conditional needed.
- Update all three .NET CI workflows (pr-checks, release, publish-nuget) to install 8.0.x + 9.0.x + 10.0.x SDKs so the multi-target build resolves on the runner.

## Test plan
- [x] `dotnet restore` — resolves on all three TFMs locally
- [x] `dotnet build -c Release` — succeeds for net8.0, net9.0, net10.0 (3 DLLs produced)
- [x] `dotnet test -c Release` — Logger.Tests 20/20 pass (net8.0)
- [x] `dotnet pack` — inspected nupkg; contains `lib/net{8,9,10}.0/SmooAI.Logger.dll`
- [x] Pre-commit hook (lint, typecheck, test, build, format) passed
- [ ] PR CI (ubuntu) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)