### PR TITLE
SMOODEV-667: Drop invalid "logging" crates.io category

### DIFF
--- a/.changeset/smoodev-667-cargo-category.md
+++ b/.changeset/smoodev-667-cargo-category.md
@@ -1,0 +1,5 @@
+---
+'@smooai/logger': patch
+---
+
+SMOODEV-667: Drop invalid `logging` crates.io category slug that was aborting the release pipeline before it could reach the NuGet publish step. crates.io only accepts categories from its fixed list (`development-tools::debugging` stays). This unblocks `SmooAI.Logger` NuGet publishes for the first time since the .NET port landed — NuGet was stuck on the 0.1.0 placeholder while npm had advanced to 4.1.2.

--- a/rust/logger/Cargo.toml
+++ b/rust/logger/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 repository = "https://github.com/SmooAI/logger"
 homepage = "https://github.com/SmooAI/logger"
 keywords = ["logging", "structured-logging", "smooai", "observability", "context"]
-categories = ["development-tools::debugging", "logging"]
+categories = ["development-tools::debugging"]
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- crates.io rejected `cargo publish` with `400 Bad Request: The following category slugs are not currently supported on crates.io: logging`. Only `development-tools::debugging` is in crates.io's fixed slug list — `logging` isn't. This aborted the release pipeline at the crates.io step for multiple cycles, so the .NET NuGet publish step never ran, leaving `SmooAI.Logger` stuck at the 0.1.0 placeholder while npm + PyPI advanced to 4.1.2.
- Drop the invalid slug. Keep the valid one.

## Why this unblocks NuGet
The release workflow runs crates.io BEFORE NuGet and has no `continue-on-error` guard, so a 400 from crates.io aborts the whole job. Fixing the category lets the pipeline reach the NuGet publish step for the first time.

## Follow-up (not in this PR)
The whole aborts-on-first-failure design is brittle — SMOODEV-667 description proposes restructuring each `release.yml` to isolate registry publishes (continue-on-error or parallel jobs) so one registry's rejection doesn't hold up the others.

## Verification
- [ ] Release workflow completes through NuGet publish step on this PR's merge
- [ ] `curl -s https://api.nuget.org/v3-flatcontainer/smooai.logger/index.json` shows the new version (4.1.x) on nuget.org
- [ ] `curl -s https://crates.io/api/v1/crates/smooai-logger` shows the crate finally published
- [ ] `npm view @smooai/logger version` and `curl -s https://pypi.org/pypi/smooai-logger/json | jq -r .info.version` match

🤖 Generated with [Claude Code](https://claude.com/claude-code)