### PR TITLE
SMOODEV-713: bump deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.13"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           python-version: "3.13"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -112,12 +112,9 @@ jobs:
 
       - name: Publish smooai-logger to crates.io
         if: steps.changesets.outputs.published == 'true'
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          # --allow-dirty is needed because version:sync modifies Cargo.toml/Cargo.lock
-          # without committing them during the CI publish flow
-          args: --allow-dirty --manifest-path rust/logger/Cargo.toml
+        # --allow-dirty is needed because version:sync modifies Cargo.toml/Cargo.lock
+        # without committing them during the CI publish flow
+        run: cargo publish --allow-dirty --manifest-path rust/logger/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.SMOOAI_CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
Part of cross-org GitHub Actions audit (SMOODEV-713).

- Bumps astral-sh/setup-uv@v3 to @v6 in pr-checks.yml and release.yml
- Replaces unmaintained actions-rs/cargo@v1 (archived, last release 2022) with run: cargo publish in release.yml

The previous crates.io '400 logging slug' failure was already fixed in code; this just removes the archived action wrapper.

## Test plan
- [ ] PR Checks runs green
- [ ] Next Release run successfully publishes smooai-logger to crates.io

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>