### PR TITLE
SMOODEV-927: Fix __filename TDZ in AwsServerLogger (4.1.4)

### DIFF
--- a/.changeset/busy-pigs-shop.md
+++ b/.changeset/busy-pigs-shop.md
@@ -1,0 +1,5 @@
+---
+"@smooai/logger": patch
+---
+
+Fix `ReferenceError: Cannot access '__filename' before initialization` (TDZ) when `AwsServerLogger` is loaded under tsx CJS interop. The old code destructured `import.meta.url` into locals named `__dirname` / `__filename` — when bundlers compile this to CJS they rewrite `import.meta.url` to a shim that reads the module-scope `__filename`, and a same-named `const` on the LHS creates a TDZ for that reference. Use a differently-named holder (`esmPaths`) so the compiled CJS doesn't self-reference a not-yet-initialized binding. This bit any tsx-run script that transitively imported `@smooai/fetch` → `@smooai/logger` (SMOODEV-908 inspect-runs, SMOODEV-918 ghl-import).

--- a/.github/workflows/build-log-viewer.yml
+++ b/.github/workflows/build-log-viewer.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   build:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,7 +6,7 @@ on:
     types: [opened, synchronize]
 
 env:
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   validate:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   CI: true
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,26 +124,22 @@
   This release transforms `@smooai/logger` into a comprehensive multi-language logging ecosystem:
 
   ### 🐍 Python Package (`smooai-logger`)
-
   - Available on PyPI as `smooai-logger`
   - Full Python implementation with identical API to TypeScript version
   - Synchronized versioning with npm package
 
   ### 🦀 Rust Crate (`smooai-logger`)
-
   - Available on crates.io as `smooai-logger`
   - Native Rust logging implementation
   - Synchronized versioning with npm package
 
   ### 📊 Log Viewer CLI (`smooai-log-viewer`)
-
   - Interactive GUI application for viewing `.smooai-logs` files
   - Available as CLI command when installing npm package: `smooai-log-viewer`
   - Cross-platform native binaries bundled with package
   - Features filtering, searching, JSON expansion, and context viewing
 
   ### 🔄 Automated Publishing Pipeline
-
   - Single changesets release now publishes to npm, PyPI, and crates.io
   - Automatic version synchronization across all packages
   - Enhanced CI/CD workflow for multi-language support

--- a/dotnet/global.json
+++ b/dotnet/global.json
@@ -1,7 +1,7 @@
 {
-    "sdk": {
-        "version": "8.0.100",
-        "rollForward": "latestMajor",
-        "allowPrerelease": false
-    }
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
 }

--- a/dotnet/src/SmooAI.Logger/README.md
+++ b/dotnet/src/SmooAI.Logger/README.md
@@ -5,7 +5,7 @@
 
 **Structured logs for .NET that carry the full story — correlation IDs, request + response, user, and caller location on every line.**
 
-.NET port of [`@smooai/logger`](https://github.com/SmooAI/logger). Drop it into a Lambda, ECS service, or worker and every log entry tells you *where* it fired, *who* triggered it, and *which request* it belonged to — without threading context through every method. JSON lines that land in CloudWatch, Datadog, or any `ILogger` sink, and wire-compatible with the TypeScript, Python, Go, and Rust ports.
+.NET port of [`@smooai/logger`](https://github.com/SmooAI/logger). Drop it into a Lambda, ECS service, or worker and every log entry tells you _where_ it fired, _who_ triggered it, and _which request_ it belonged to — without threading context through every method. JSON lines that land in CloudWatch, Datadog, or any `ILogger` sink, and wire-compatible with the TypeScript, Python, Go, and Rust ports.
 
 ## Install
 
@@ -54,7 +54,7 @@ Output (CloudWatch-friendly JSON line):
   "msg": "Order placed",
   "orderId": "ord_123",
   "userId": "u_456",
-  "total": 42.00
+  "total": 42.0
 }
 ```
 
@@ -114,10 +114,10 @@ The SmooLogger still emits JSON to stdout **and** forwards the structured payloa
 
 ## Environment
 
-| Variable | Values | Default | Effect |
-|----------|--------|---------|--------|
-| `LOG_LEVEL` | `trace` `debug` `info` `warn` `error` `fatal` | `info` | Minimum level emitted |
-| `IS_LOCAL`, `SST_DEV`, `GITHUB_ACTIONS` | `"true"` | — | Enables pretty-print |
+| Variable                                | Values                                        | Default | Effect                |
+| --------------------------------------- | --------------------------------------------- | ------- | --------------------- |
+| `LOG_LEVEL`                             | `trace` `debug` `info` `warn` `error` `fatal` | `info`  | Minimum level emitted |
+| `IS_LOCAL`, `SST_DEV`, `GITHUB_ACTIONS` | `"true"`                                      | —       | Enables pretty-print  |
 
 ## Related
 

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -80,7 +80,9 @@ const updates = [
     apply(content) {
       const pattern = /(<Version>)([^<]+)(<\/Version>)/;
       if (!pattern.test(content)) {
-        throw new Error("<Version> element not found in dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj");
+        throw new Error(
+          "<Version> element not found in dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj",
+        );
       }
       return content.replace(pattern, `$1${version}$3`);
     },

--- a/src/AwsServerLogger.ts
+++ b/src/AwsServerLogger.ts
@@ -27,11 +27,15 @@ export type SQSBatchMessageAttributes = Record<string, MessageAttributeValue>;
 sourceMapSupport.install();
 
 if (!global.__dirname || !global.__filename) {
-  const { __dirname, __filename } = import.meta.url
+  // Don't destructure into locals named `__dirname`/`__filename` — when bundlers
+  // transpile this module to CJS they rewrite `import.meta.url` to a shim that
+  // reads the CJS-module-scope `__filename`, and a same-named `const` on the
+  // LHS creates a TDZ for that reference. Use a differently-named holder.
+  const esmPaths = import.meta.url
     ? createEsmUtils({ url: import.meta.url, resolve: import.meta.resolve } as any)
     : { __dirname: "", __filename: "" };
-  global.__dirname = global.__dirname ? global.__dirname : __dirname;
-  global.__filename = global.__filename ? global.__filename : __filename;
+  global.__dirname = global.__dirname ? global.__dirname : esmPaths.__dirname;
+  global.__filename = global.__filename ? global.__filename : esmPaths.__filename;
 }
 
 type AnyFunction = (...args: any[]) => any;


### PR DESCRIPTION
Published 4.1.3 dist still contained the broken destructure of `import.meta.url` into local consts named `__dirname`/`__filename` — under tsx CJS interop this creates a TDZ on the rhs reference to `__filename`. Hits any tsx-run script that transitively imports `@smooai/fetch` → `@smooai/logger`.

Fix: use an `esmPaths` holder with different names so the compiled CJS doesn't self-reference a not-yet-initialized binding.

Originally observed in SMOODEV-908 (inspect-runs.ts) + SMOODEV-918 (one-off GHL import script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)