### PR TITLE
SMOODEV-945: Go logger — add AddECSContext for Fargate parity

### DIFF
--- a/.changeset/smoodev-945-go-ecs-context.md
+++ b/.changeset/smoodev-945-go-ecs-context.md
@@ -1,0 +1,5 @@
+---
+"@smooai/logger": patch
+---
+
+SMOODEV-945: Go port — add `LambdaLogger.AddECSContext()` for Fargate/ECS parity with Python. Reads the standard ECS-on-Fargate / Amazon-ECS-Agent env vars (`ECS_CONTAINER_METADATA_URI_V4`, `AWS_EXECUTION_ENV`, `AWS_REGION`, etc.) and attaches them under an `ecs` key in the logger context. Previously the Go port had Lambda / SQS / API Gateway / LambdaEnvironment context helpers but no ECS counterpart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,26 +130,22 @@
   This release transforms `@smooai/logger` into a comprehensive multi-language logging ecosystem:
 
   ### 🐍 Python Package (`smooai-logger`)
-
   - Available on PyPI as `smooai-logger`
   - Full Python implementation with identical API to TypeScript version
   - Synchronized versioning with npm package
 
   ### 🦀 Rust Crate (`smooai-logger`)
-
   - Available on crates.io as `smooai-logger`
   - Native Rust logging implementation
   - Synchronized versioning with npm package
 
   ### 📊 Log Viewer CLI (`smooai-log-viewer`)
-
   - Interactive GUI application for viewing `.smooai-logs` files
   - Available as CLI command when installing npm package: `smooai-log-viewer`
   - Cross-platform native binaries bundled with package
   - Features filtering, searching, JSON expansion, and context viewing
 
   ### 🔄 Automated Publishing Pipeline
-
   - Single changesets release now publishes to npm, PyPI, and crates.io
   - Automatic version synchronization across all packages
   - Enhanced CI/CD workflow for multi-language support

--- a/go/lambda.go
+++ b/go/lambda.go
@@ -80,6 +80,22 @@ func (l *LambdaLogger) AddLambdaEnvironmentContext() {
 	}
 }
 
+// AddECSContext adds ECS task/container metadata to the logger context under
+// the "ecs" key, mirroring Python's aws_logger.add_ecs_context. Reads the
+// standard ECS-on-Fargate / Amazon-ECS-Agent env vars.
+func (l *LambdaLogger) AddECSContext() {
+	ecsCtx := Map{
+		"containerCredentialsRelativeUri": os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"),
+		"containerMetadataUriV4":          os.Getenv("ECS_CONTAINER_METADATA_URI_V4"),
+		"containerMetadataUri":            os.Getenv("ECS_CONTAINER_METADATA_URI"),
+		"agentUri":                        os.Getenv("ECS_AGENT_URI"),
+		"executionEnv":                    os.Getenv("AWS_EXECUTION_ENV"),
+		"defaultRegion":                   os.Getenv("AWS_DEFAULT_REGION"),
+		"region":                          os.Getenv("AWS_REGION"),
+	}
+	l.AddBaseContext(Map{"ecs": ecsCtx})
+}
+
 // AddSQSRecordContext adds SQS message context to the logger, including
 // message ID, event source, event source ARN, and receipt handle.
 func (l *LambdaLogger) AddSQSRecordContext(record events.SQSMessage) {

--- a/go/lambda_test.go
+++ b/go/lambda_test.go
@@ -103,6 +103,35 @@ func TestAddLambdaEnvironmentContext(t *testing.T) {
 	}
 }
 
+func TestAddECSContext(t *testing.T) {
+	resetGlobalContext()
+	os.Setenv("ECS_CONTAINER_METADATA_URI_V4", "http://169.254.170.2/v4/abc")
+	os.Setenv("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE")
+	os.Setenv("AWS_REGION", "us-east-1")
+	defer os.Unsetenv("ECS_CONTAINER_METADATA_URI_V4")
+	defer os.Unsetenv("AWS_EXECUTION_ENV")
+	defer os.Unsetenv("AWS_REGION")
+
+	l := Default()
+	ll := NewLambdaLogger(l)
+	ll.AddECSContext()
+
+	logCtx := ll.Context()
+	ecsMap, ok := logCtx["ecs"].(Map)
+	if !ok {
+		t.Fatal("ecs context should be present")
+	}
+	if ecsMap["containerMetadataUriV4"] != "http://169.254.170.2/v4/abc" {
+		t.Errorf("containerMetadataUriV4 = %v", ecsMap["containerMetadataUriV4"])
+	}
+	if ecsMap["executionEnv"] != "AWS_ECS_FARGATE" {
+		t.Errorf("executionEnv = %v", ecsMap["executionEnv"])
+	}
+	if ecsMap["region"] != "us-east-1" {
+		t.Errorf("region = %v", ecsMap["region"])
+	}
+}
+
 func TestAddSQSRecordContext(t *testing.T) {
 	resetGlobalContext()
 	l := Default()


### PR DESCRIPTION
## Summary
Mirrors Python's `aws_logger.add_ecs_context`. Reads standard ECS-on-Fargate env vars and attaches them under an `ecs` key.

## Test plan
- [x] go build / go vet / go test ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)