### PR TITLE
SMOODEV-942: Redact sensitive headers/fields across all 5 ports

### DIFF
--- a/.changeset/smoodev-942-redact-sensitive-fields.md
+++ b/.changeset/smoodev-942-redact-sensitive-fields.md
@@ -1,0 +1,5 @@
+---
+"@smooai/logger": patch
+---
+
+SMOODEV-942: Add sensitive-field redaction across all 5 ports (TS, Python, Rust, Go, .NET). Logger now redacts a default set of auth-bearing HTTP headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, `x-amz-security-token`, `proxy-authorization`) and credential-shaped field names (`password`, `passwd`, `secret`, `apiKey`, `api_key`, `token`, `access_token`, `refresh_token`, `client_secret`) before logs are emitted — replacing values with `"[REDACTED]"`. Matching is case-insensitive. Each port exposes `addRedactKeys()` / `AddRedactKeys()` / `add_redact_keys()` to extend the list, plus a constructor option to override the defaults entirely (pass an empty list to disable). Previously every port logged HTTP request headers and request bodies as-is, leaking Bearer tokens and cookies into CloudWatch / log shipping pipelines.

--- a/dotnet/src/SmooAI.Logger/SmooLogger.cs
+++ b/dotnet/src/SmooAI.Logger/SmooLogger.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 
@@ -14,6 +15,34 @@ namespace SmooAI.Logger;
 /// </summary>
 public class SmooLogger
 {
+    /// <summary>
+    /// Default list of context keys whose values are replaced with
+    /// <see cref="RedactedValue"/> before logging. Matching is case-insensitive.
+    /// </summary>
+    public static readonly IReadOnlyList<string> DefaultRedactKeys = new[]
+    {
+        // Auth-bearing HTTP headers
+        "authorization",
+        "proxy-authorization",
+        "cookie",
+        "set-cookie",
+        "x-api-key",
+        "x-amz-security-token",
+        // Common credential / token field names
+        "password",
+        "passwd",
+        "secret",
+        "apikey",
+        "api_key",
+        "token",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+    };
+
+    /// <summary>Placeholder substituted for any redacted value.</summary>
+    public const string RedactedValue = "[REDACTED]";
+
     private static readonly JsonSerializerOptions CompactJson = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -32,6 +61,7 @@ public class SmooLogger
     private readonly TextWriter _output;
     private readonly ILogger? _forwardTo;
     private readonly bool _prettyPrint;
+    private readonly HashSet<string> _redactKeys;
     private string _name;
     private Level _level;
 
@@ -71,6 +101,9 @@ public class SmooLogger
         _output = options.Output ?? Console.Out;
         _forwardTo = options.ForwardTo;
         _prettyPrint = options.PrettyPrint ?? IsLocalEnv();
+        _redactKeys = new HashSet<string>(
+            (options.RedactKeys ?? DefaultRedactKeys).Select(k => k.ToLowerInvariant()),
+            StringComparer.Ordinal);
 
         var correlationId = Guid.NewGuid().ToString();
         _context[ContextKey.CorrelationId] = correlationId;
@@ -96,6 +129,58 @@ public class SmooLogger
         var opts = new SmooLoggerOptions { Name = typeof(T).Name };
         configure?.Invoke(opts);
         return new SmooLogger(opts);
+    }
+
+    /// <summary>
+    /// Returns a snapshot of the current redact-keys list (lowercased).
+    /// </summary>
+    public IReadOnlyCollection<string> RedactKeys
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _redactKeys.ToArray();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds keys to the redact-keys list. Existing entries are preserved.
+    /// Matching is case-insensitive (stored lowercased).
+    /// </summary>
+    public void AddRedactKeys(IEnumerable<string> keys)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        lock (_gate)
+        {
+            foreach (var key in keys)
+            {
+                if (!string.IsNullOrEmpty(key))
+                {
+                    _redactKeys.Add(key.ToLowerInvariant());
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Replaces the redact-keys list. Pass an empty enumerable to disable redaction.
+    /// </summary>
+    public void SetRedactKeys(IEnumerable<string> keys)
+    {
+        ArgumentNullException.ThrowIfNull(keys);
+        lock (_gate)
+        {
+            _redactKeys.Clear();
+            foreach (var key in keys)
+            {
+                if (!string.IsNullOrEmpty(key))
+                {
+                    _redactKeys.Add(key.ToLowerInvariant());
+                }
+            }
+        }
     }
 
     // ------------- Context mutators -------------
@@ -431,6 +516,58 @@ public class SmooLogger
         entry[ContextKey.Context] = nested;
     }
 
+    private string ApplyRedaction(string json, JsonSerializerOptions serializerOpts)
+    {
+        HashSet<string> redactSnapshot;
+        lock (_gate)
+        {
+            if (_redactKeys.Count == 0) return json;
+            redactSnapshot = new HashSet<string>(_redactKeys, StringComparer.Ordinal);
+        }
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(json);
+        }
+        catch
+        {
+            return json;
+        }
+        if (node == null) return json;
+
+        RedactNode(node, redactSnapshot);
+        return node.ToJsonString(serializerOpts);
+    }
+
+    private static void RedactNode(JsonNode node, HashSet<string> redactSet)
+    {
+        if (node is JsonObject obj)
+        {
+            var keys = obj.Select(kv => kv.Key).ToArray();
+            foreach (var key in keys)
+            {
+                if (redactSet.Contains(key.ToLowerInvariant()))
+                {
+                    obj[key] = JsonValue.Create(RedactedValue);
+                }
+                else
+                {
+                    var child = obj[key];
+                    if (child != null) RedactNode(child, redactSet);
+                }
+            }
+        }
+        else if (node is JsonArray arr)
+        {
+            for (int i = 0; i < arr.Count; i++)
+            {
+                var child = arr[i];
+                if (child != null) RedactNode(child, redactSet);
+            }
+        }
+    }
+
     private void WriteEntry(Dictionary<string, object?> entry, Level level, string message, Exception? error)
     {
         var opts = _prettyPrint ? PrettyJson : CompactJson;
@@ -438,6 +575,7 @@ public class SmooLogger
         try
         {
             json = JsonSerializer.Serialize(entry, opts);
+            json = ApplyRedaction(json, opts);
         }
         catch (Exception serializeEx)
         {

--- a/dotnet/src/SmooAI.Logger/SmooLoggerOptions.cs
+++ b/dotnet/src/SmooAI.Logger/SmooLoggerOptions.cs
@@ -29,4 +29,11 @@ public sealed class SmooLoggerOptions
     /// sinks wired through <c>ILoggerFactory</c> continue to receive the entry.
     /// </summary>
     public Microsoft.Extensions.Logging.ILogger? ForwardTo { get; set; }
+
+    /// <summary>
+    /// Overrides the redact-keys list. When <c>null</c>, defaults from
+    /// <see cref="SmooLogger.DefaultRedactKeys"/> are used. Pass an empty
+    /// enumerable to disable redaction entirely. Matching is case-insensitive.
+    /// </summary>
+    public IEnumerable<string>? RedactKeys { get; set; }
 }

--- a/dotnet/tests/SmooAI.Logger.Tests/SmooLoggerTests.cs
+++ b/dotnet/tests/SmooAI.Logger.Tests/SmooLoggerTests.cs
@@ -278,6 +278,87 @@ public class SmooLoggerTests
     }
 
     [Fact]
+    public void Default_Redacts_Auth_Headers_In_Http_Request()
+    {
+        var (logger, writer) = Build();
+        logger.AddHttpRequest(new SmooHttpRequest
+        {
+            Method = "POST",
+            Path = "/api/x",
+            Headers = new Dictionary<string, string>
+            {
+                ["Authorization"] = "Bearer super-secret",
+                ["Cookie"] = "session=abc",
+                ["X-Api-Key"] = "k_xxx",
+                ["x-amz-security-token"] = "AQoDY...",
+                ["User-Agent"] = "smoo/1.0",
+            }
+        });
+        logger.LogInfo("req received");
+        var entry = ParseSingle(writer.ToString());
+
+        var headers = entry.GetProperty("http").GetProperty("request").GetProperty("headers");
+        Assert.Equal(SmooLogger.RedactedValue, headers.GetProperty("Authorization").GetString());
+        Assert.Equal(SmooLogger.RedactedValue, headers.GetProperty("Cookie").GetString());
+        Assert.Equal(SmooLogger.RedactedValue, headers.GetProperty("X-Api-Key").GetString());
+        Assert.Equal(SmooLogger.RedactedValue, headers.GetProperty("x-amz-security-token").GetString());
+        Assert.Equal("smoo/1.0", headers.GetProperty("User-Agent").GetString());
+    }
+
+    [Fact]
+    public void Default_Redacts_Secret_Field_Names_Case_Insensitive()
+    {
+        var (logger, writer) = Build();
+        logger.LogInfo("ctx", new Dictionary<string, object?>
+        {
+            ["Password"] = "hunter2",
+            ["api_key"] = "sk_xxx",
+            ["refresh_token"] = "rt-2",
+            ["client_secret"] = "cs",
+            ["visible"] = "ok",
+        });
+        var entry = ParseSingle(writer.ToString());
+        var ctx = entry.GetProperty("context");
+        Assert.Equal(SmooLogger.RedactedValue, ctx.GetProperty("Password").GetString());
+        Assert.Equal(SmooLogger.RedactedValue, ctx.GetProperty("api_key").GetString());
+        Assert.Equal(SmooLogger.RedactedValue, ctx.GetProperty("refresh_token").GetString());
+        Assert.Equal(SmooLogger.RedactedValue, ctx.GetProperty("client_secret").GetString());
+        Assert.Equal("ok", ctx.GetProperty("visible").GetString());
+    }
+
+    [Fact]
+    public void AddRedactKeys_Extends_Default_List()
+    {
+        var (logger, writer) = Build();
+        logger.AddRedactKeys(new[] { "customSecret" });
+        logger.LogInfo("ctx", new Dictionary<string, object?>
+        {
+            ["customSecret"] = "shh",
+            ["visible"] = "ok",
+        });
+        var entry = ParseSingle(writer.ToString());
+        var ctx = entry.GetProperty("context");
+        Assert.Equal(SmooLogger.RedactedValue, ctx.GetProperty("customSecret").GetString());
+        Assert.Equal("ok", ctx.GetProperty("visible").GetString());
+    }
+
+    [Fact]
+    public void RedactKeys_Constructor_Override_Disables_Defaults()
+    {
+        var (logger, writer) = Build(o => o.RedactKeys = new[] { "onlyThis" });
+        logger.LogInfo("ctx", new Dictionary<string, object?>
+        {
+            ["onlyThis"] = "x",
+            ["authorization"] = "Bearer plaintext-leak",
+        });
+        var entry = ParseSingle(writer.ToString());
+        var ctx = entry.GetProperty("context");
+        Assert.Equal(SmooLogger.RedactedValue, ctx.GetProperty("onlyThis").GetString());
+        // Default `authorization` was overridden — should NOT be redacted
+        Assert.Equal("Bearer plaintext-leak", ctx.GetProperty("authorization").GetString());
+    }
+
+    [Fact]
     public void Concurrent_Logging_Does_Not_Throw()
     {
         var (logger, writer) = Build();

--- a/go/context_config.go
+++ b/go/context_config.go
@@ -1,5 +1,76 @@
 package logger
 
+import "strings"
+
+// DefaultRedactKeys returns the default list of context keys whose values
+// will be replaced with [RedactedValue] before logging. Matching is
+// case-insensitive.
+func DefaultRedactKeys() []string {
+	return []string{
+		// Auth-bearing HTTP headers
+		"authorization",
+		"proxy-authorization",
+		"cookie",
+		"set-cookie",
+		"x-api-key",
+		"x-amz-security-token",
+		// Common credential / token field names
+		"password",
+		"passwd",
+		"secret",
+		"apikey",
+		"api_key",
+		"token",
+		"access_token",
+		"refresh_token",
+		"client_secret",
+	}
+}
+
+// RedactedValue is the placeholder string substituted in place of any
+// redacted value.
+const RedactedValue = "[REDACTED]"
+
+// redactSensitiveValues recursively walks `data` and replaces any field whose
+// key matches an entry in `redactSet` (case-insensitive) with [RedactedValue].
+// `redactSet` is keyed by lowercase entries.
+func redactSensitiveValues(data any, redactSet map[string]struct{}) any {
+	if len(redactSet) == 0 || data == nil {
+		return data
+	}
+	switch v := data.(type) {
+	case Map:
+		for k, val := range v {
+			if _, ok := redactSet[strings.ToLower(k)]; ok {
+				v[k] = RedactedValue
+			} else {
+				v[k] = redactSensitiveValues(val, redactSet)
+			}
+		}
+		return v
+	case []any:
+		for i, item := range v {
+			v[i] = redactSensitiveValues(item, redactSet)
+		}
+		return v
+	case map[string]string:
+		// HTTP header maps are commonly stored as map[string]string. Promote
+		// to a Map so we can mutate string values to "[REDACTED]" alongside
+		// the structured payload.
+		promoted := make(Map, len(v))
+		for k, val := range v {
+			if _, ok := redactSet[strings.ToLower(k)]; ok {
+				promoted[k] = RedactedValue
+			} else {
+				promoted[k] = val
+			}
+		}
+		return promoted
+	default:
+		return v
+	}
+}
+
 // ContextConfigType represents the type of context config filter.
 type ContextConfigType int
 

--- a/go/logger.go
+++ b/go/logger.go
@@ -27,6 +27,10 @@ type Options struct {
 	Rotation      *RotationOptions
 	Context       Map
 	ContextConfig *ContextConfig
+	// RedactKeys overrides the default redact-keys list. If nil, [DefaultRedactKeys]
+	// is used. Matching is case-insensitive. Set to a non-nil empty slice to disable
+	// redaction entirely.
+	RedactKeys []string
 }
 
 // Logger is a structured JSON logger that writes to stdout and optionally
@@ -40,6 +44,7 @@ type Logger struct {
 	contextConfig *ContextConfig
 	writer        *rotatingWriter
 	output        io.Writer
+	redactKeys    map[string]struct{} // lowercased
 }
 
 // New creates a new Logger with the given options.
@@ -112,6 +117,15 @@ func New(opts Options) (*Logger, error) {
 		}
 	}
 
+	redactSeed := opts.RedactKeys
+	if redactSeed == nil {
+		redactSeed = DefaultRedactKeys()
+	}
+	redactKeys := make(map[string]struct{}, len(redactSeed))
+	for _, k := range redactSeed {
+		redactKeys[strings.ToLower(k)] = struct{}{}
+	}
+
 	return &Logger{
 		name:          name,
 		level:         level,
@@ -121,7 +135,41 @@ func New(opts Options) (*Logger, error) {
 		contextConfig: opts.ContextConfig,
 		writer:        rw,
 		output:        os.Stdout,
+		redactKeys:    redactKeys,
 	}, nil
+}
+
+// RedactKeys returns the current redact-keys list (lowercased, sorted).
+func (l *Logger) RedactKeys() []string {
+	out := make([]string, 0, len(l.redactKeys))
+	for k := range l.redactKeys {
+		out = append(out, k)
+	}
+	// sort for stable output
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// SetRedactKeys replaces the redact-keys list. Keys are stored lowercased.
+func (l *Logger) SetRedactKeys(keys []string) {
+	l.redactKeys = make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		l.redactKeys[strings.ToLower(k)] = struct{}{}
+	}
+}
+
+// AddRedactKeys adds keys to the redact-keys list. Existing entries are preserved.
+func (l *Logger) AddRedactKeys(keys ...string) {
+	if l.redactKeys == nil {
+		l.redactKeys = make(map[string]struct{}, len(keys))
+	}
+	for _, k := range keys {
+		l.redactKeys[strings.ToLower(k)] = struct{}{}
+	}
 }
 
 // Default creates a Logger with default settings.
@@ -345,6 +393,9 @@ func (l *Logger) buildLogObject(level Level, msg string, args []any) Map {
 	}
 
 	removeNils(payload)
+	if v, ok := redactSensitiveValues(payload, l.redactKeys).(Map); ok {
+		payload = v
+	}
 	return payload
 }
 

--- a/go/logger_test.go
+++ b/go/logger_test.go
@@ -717,3 +717,94 @@ func TestErrorWithoutMessage(t *testing.T) {
 		t.Errorf("msg = %v, want %q", payload[KeyMessage], "standalone error")
 	}
 }
+
+func TestRedactDefaultAuthHeaders(t *testing.T) {
+	resetGlobalContext()
+	var buf bytes.Buffer
+	l := Default()
+	l.output = &buf
+	l.prettyPrint = false
+
+	l.AddHTTPRequest(HTTPRequest{
+		Method: "POST",
+		Path:   "/api/x",
+		Headers: map[string]string{
+			"Authorization":        "Bearer super-secret",
+			"Cookie":               "session=abc",
+			"X-Api-Key":            "k_xxx",
+			"x-amz-security-token": "AQoDY...",
+			"User-Agent":           "smoo/1.0",
+		},
+	})
+	_ = l.Info("req received")
+
+	var payload map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("Failed to parse log output: %v", err)
+	}
+	httpCtx, _ := payload[KeyHTTP].(map[string]any)
+	req, _ := httpCtx["request"].(map[string]any)
+	headers, _ := req["headers"].(map[string]any)
+
+	for _, k := range []string{"Authorization", "Cookie", "X-Api-Key", "x-amz-security-token"} {
+		if headers[k] != RedactedValue {
+			t.Errorf("expected %q to be redacted, got %v", k, headers[k])
+		}
+	}
+	if headers["User-Agent"] != "smoo/1.0" {
+		t.Errorf("non-sensitive User-Agent header should be preserved, got %v", headers["User-Agent"])
+	}
+}
+
+func TestRedactSecretFieldNamesCaseInsensitive(t *testing.T) {
+	resetGlobalContext()
+	var buf bytes.Buffer
+	l := Default()
+	l.output = &buf
+	l.prettyPrint = false
+
+	_ = l.Info("ctx", Map{
+		"Password":      "hunter2",
+		"api_key":       "sk_xxx",
+		"refresh_token": "rt-2",
+		"client_secret": "cs",
+		"visible":       "ok",
+	})
+
+	var payload map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("Failed to parse log output: %v", err)
+	}
+	ctx, _ := payload[KeyContext].(map[string]any)
+	for _, k := range []string{"Password", "api_key", "refresh_token", "client_secret"} {
+		if ctx[k] != RedactedValue {
+			t.Errorf("expected %q to be redacted, got %v", k, ctx[k])
+		}
+	}
+	if ctx["visible"] != "ok" {
+		t.Errorf("visible should not be redacted")
+	}
+}
+
+func TestAddRedactKeysExtendsDefaults(t *testing.T) {
+	resetGlobalContext()
+	var buf bytes.Buffer
+	l := Default()
+	l.output = &buf
+	l.prettyPrint = false
+
+	l.AddRedactKeys("customSecret")
+	_ = l.Info("ctx", Map{"customSecret": "shh", "visible": "ok"})
+
+	var payload map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("Failed to parse log output: %v", err)
+	}
+	ctx, _ := payload[KeyContext].(map[string]any)
+	if ctx["customSecret"] != RedactedValue {
+		t.Errorf("expected customSecret redacted, got %v", ctx["customSecret"])
+	}
+	if ctx["visible"] != "ok" {
+		t.Errorf("visible should remain, got %v", ctx["visible"])
+	}
+}

--- a/python/src/smooai_logger/__init__.py
+++ b/python/src/smooai_logger/__init__.py
@@ -2,6 +2,8 @@
 
 from .aws_logger import AwsServerLogger
 from .logger import (
+    DEFAULT_REDACT_KEYS,
+    REDACTED_VALUE,
     Context,
     HttpContext,
     HttpRequestContext,
@@ -26,6 +28,8 @@ from .uvicorn_logger_adapter import UvicornLoggerAdapter, configure_uvicorn_logg
 __all__ = [
     "AwsServerLogger",
     "Context",
+    "DEFAULT_REDACT_KEYS",
+    "REDACTED_VALUE",
     "HttpContext",
     "HttpRequestContext",
     "HttpResponseContext",

--- a/python/src/smooai_logger/logger.py
+++ b/python/src/smooai_logger/logger.py
@@ -280,6 +280,31 @@ def reset_global_context() -> None:
 
 
 # --------------------------------------------------------------------------------
+# Sensitive-field redaction defaults
+# --------------------------------------------------------------------------------
+DEFAULT_REDACT_KEYS: list[str] = [
+    # Auth-bearing HTTP headers
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "x-amz-security-token",
+    # Common credential / token field names
+    "password",
+    "passwd",
+    "secret",
+    "apikey",
+    "api_key",
+    "token",
+    "access_token",
+    "refresh_token",
+    "client_secret",
+]
+REDACTED_VALUE: str = "[REDACTED]"
+
+
+# --------------------------------------------------------------------------------
 class Level(str, Enum):
     TRACE = "trace"
     DEBUG = "debug"
@@ -303,6 +328,7 @@ class Logger:
         pretty_print: bool | None = None,
         log_to_file: bool | None = None,
         rotation_options: RotationOptions | None = None,
+        redact_keys: list[str] | None = None,
     ) -> None:
         # Initialize global context if provided
         if context:
@@ -318,9 +344,46 @@ class Logger:
         self._file_handler: RotatingFileHandler | TimedRotatingFileHandler | None = None
         self._rotation_config: RotationConfig | None = None
 
+        # Redaction config — keys are stored lowercase for case-insensitive matching
+        seed = redact_keys if redact_keys is not None else DEFAULT_REDACT_KEYS
+        self._redact_keys: set[str] = {k.lower() for k in seed}
+
         # Set up rotating file if requested
         if self.log_to_file:
             self._setup_rotation_handler(rotation_options)
+
+    @property
+    def redact_keys(self) -> list[str]:
+        """Return the current redact-keys list (lowercased)."""
+        return sorted(self._redact_keys)
+
+    @redact_keys.setter
+    def redact_keys(self, keys: list[str]) -> None:
+        """Replace the redact-keys list (stored lowercased)."""
+        self._redact_keys = {k.lower() for k in keys}
+
+    def add_redact_keys(self, keys: list[str]) -> None:
+        """Add keys to the redact list. Existing entries are preserved."""
+        for k in keys:
+            self._redact_keys.add(k.lower())
+
+    def _redact_sensitive_values(self, obj: Any) -> Any:
+        """Recursively replace values for any key (case-insensitive) matching the redact list."""
+        if not self._redact_keys:
+            return obj
+        if isinstance(obj, dict):
+            out: dict[str, Any] = {}
+            for k, v in obj.items():  # pyright: ignore[reportUnknownVariableType]
+                if isinstance(k, str) and k.lower() in self._redact_keys:
+                    out[k] = REDACTED_VALUE
+                else:
+                    out[k] = self._redact_sensitive_values(v)
+            return out
+        if isinstance(obj, list):
+            return [self._redact_sensitive_values(v) for v in obj]  # pyright: ignore[reportUnknownVariableType]
+        if isinstance(obj, tuple):
+            return tuple(self._redact_sensitive_values(v) for v in obj)  # pyright: ignore[reportUnknownVariableType]
+        return obj
 
     def reset_context(self) -> None:
         """Reset the global context to its initial state."""
@@ -572,7 +635,8 @@ class Logger:
             if key in rec:
                 ordered[key] = rec.pop(key)
         ordered.update(rec)  # pyright: ignore[reportUnknownMemberType]
-        return self._remove_none(self._apply_context_config(cast(Context, cast(object, ordered))))
+        cleaned = self._remove_none(self._apply_context_config(cast(Context, cast(object, ordered))))
+        return cast(Context, cast(object, self._redact_sensitive_values(cleaned)))
 
     def _pretty_emit(self, record: Context) -> None:
         sep = "-" * 100

--- a/python/tests/test_logger.py
+++ b/python/tests/test_logger.py
@@ -461,3 +461,88 @@ class TestLoggerIntegration:
         assert "errorDetails" in parsed
         assert "callerContext" in parsed
         assert "time" in parsed
+
+
+class TestLoggerRedaction:
+    """Sensitive-field redaction (SMOODEV-942)."""
+
+    def setup_method(self):
+        reset_global_context()
+
+    def test_default_redacts_auth_headers_in_request_context(self):
+        from smooai_logger import REDACTED_VALUE
+
+        logger = Logger(name="RedactTest", level=Level.INFO, pretty_print=False)
+        request: HttpRequestContext = {
+            "method": "POST",
+            "path": "/api/x",
+            "headers": {
+                "Authorization": "Bearer super-secret-token",
+                "Cookie": "session=abc123",
+                "X-Api-Key": "k_xxx",
+                "x-amz-security-token": "AQoDY...",
+                "User-Agent": "smoo/1.0",
+            },
+        }
+        logger.add_request_context(request)
+
+        record = logger._build_record(Level.INFO, ["hello"])
+        http = record.get("http") or {}
+        req = http.get("request") or {}
+        headers = req.get("headers") or {}
+
+        assert headers["Authorization"] == REDACTED_VALUE
+        assert headers["Cookie"] == REDACTED_VALUE
+        assert headers["X-Api-Key"] == REDACTED_VALUE
+        assert headers["x-amz-security-token"] == REDACTED_VALUE
+        # Non-sensitive header preserved
+        assert headers["User-Agent"] == "smoo/1.0"
+
+    def test_default_redacts_password_secret_token_in_context(self):
+        from smooai_logger import REDACTED_VALUE
+
+        logger = Logger(name="RedactTest", level=Level.INFO, pretty_print=False)
+        record = logger._build_record(
+            Level.INFO,
+            [
+                {
+                    "Password": "hunter2",
+                    "api_key": "sk_xxx",
+                    "refresh_token": "rt-2",
+                    "client_secret": "cs_xxx",
+                    "visible": "ok",
+                }
+            ],
+        )
+        ctx = record.get("context") or {}
+        assert ctx["Password"] == REDACTED_VALUE
+        assert ctx["api_key"] == REDACTED_VALUE
+        assert ctx["refresh_token"] == REDACTED_VALUE
+        assert ctx["client_secret"] == REDACTED_VALUE
+        assert ctx["visible"] == "ok"
+
+    def test_add_redact_keys_extends_list(self):
+        from smooai_logger import REDACTED_VALUE
+
+        logger = Logger(name="RedactTest", level=Level.INFO, pretty_print=False)
+        logger.add_redact_keys(["customSecret"])
+        record = logger._build_record(Level.INFO, [{"customSecret": "shh", "ok": 1}])
+        ctx = record.get("context") or {}
+        assert ctx["customSecret"] == REDACTED_VALUE
+        assert ctx["ok"] == 1
+
+    def test_redact_keys_constructor_override(self):
+        logger = Logger(
+            name="RedactTest",
+            level=Level.INFO,
+            pretty_print=False,
+            redact_keys=["onlyThis"],
+        )
+        record = logger._build_record(
+            Level.INFO,
+            [{"onlyThis": "x", "authorization": "Bearer plaintext"}],
+        )
+        ctx = record.get("context") or {}
+        assert ctx["onlyThis"] == "[REDACTED]"
+        # Default `authorization` was overridden away, so still visible
+        assert ctx["authorization"] == "Bearer plaintext"

--- a/rust/logger/src/context.rs
+++ b/rust/logger/src/context.rs
@@ -158,6 +158,58 @@ pub static CONFIG_MINIMAL: Lazy<ContextConfig> = Lazy::new(|| {
 
 pub const CONFIG_FULL: ContextConfig = ContextConfig::AllowAll;
 
+/// Default list of context keys whose values are replaced with `"[REDACTED]"`
+/// before logging. Matching is case-insensitive.
+pub fn default_redact_keys() -> Vec<String> {
+    vec![
+        // Auth-bearing HTTP headers
+        "authorization".into(),
+        "proxy-authorization".into(),
+        "cookie".into(),
+        "set-cookie".into(),
+        "x-api-key".into(),
+        "x-amz-security-token".into(),
+        // Common credential / token field names
+        "password".into(),
+        "passwd".into(),
+        "secret".into(),
+        "apikey".into(),
+        "api_key".into(),
+        "token".into(),
+        "access_token".into(),
+        "refresh_token".into(),
+        "client_secret".into(),
+    ]
+}
+
+/// Placeholder string substituted in place of any redacted value.
+pub const REDACTED_VALUE: &str = "[REDACTED]";
+
+/// Recursively walks `value` and replaces any field whose key matches an entry
+/// in `redact_keys` (case-insensitive) with `REDACTED_VALUE`.
+pub fn redact_sensitive_values(value: &mut Value, redact_keys: &std::collections::HashSet<String>) {
+    if redact_keys.is_empty() {
+        return;
+    }
+    match value {
+        Value::Object(map) => {
+            for (k, v) in map.iter_mut() {
+                if redact_keys.contains(&k.to_lowercase()) {
+                    *v = Value::String(REDACTED_VALUE.to_string());
+                } else {
+                    redact_sensitive_values(v, redact_keys);
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for item in arr.iter_mut() {
+                redact_sensitive_values(item, redact_keys);
+            }
+        }
+        _ => {}
+    }
+}
+
 static GLOBAL_CONTEXT: Lazy<RwLock<ContextValue>> = Lazy::new(|| RwLock::new(Value::Object(default_context_map())));
 
 fn default_context_map() -> ContextMap {

--- a/rust/logger/src/lib.rs
+++ b/rust/logger/src/lib.rs
@@ -11,7 +11,7 @@ pub mod logger;
 pub mod pretty;
 pub mod rotation;
 
-pub use crate::context::{ContextConfig, ContextKey, ContextValue, CONFIG_FULL, CONFIG_MINIMAL};
+pub use crate::context::{default_redact_keys, ContextConfig, ContextKey, ContextValue, CONFIG_FULL, CONFIG_MINIMAL, REDACTED_VALUE};
 pub use crate::error::{log_error, LoggedError};
 pub use crate::logger::{Level, LogArgs, Logger, LoggerOptions};
 pub use crate::rotation::RotationOptions;

--- a/rust/logger/src/logger.rs
+++ b/rust/logger/src/logger.rs
@@ -10,8 +10,9 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::context::{
-    self, add_base_context, add_nested_context, apply_context_config, base_context_key, context_value, remove_nulls, reset_global_context, set_correlation_id,
-    ContextConfig, ContextKey, HttpRequest, HttpResponse, TelemetryFields, User, CONFIG_FULL, CONFIG_MINIMAL,
+    self, add_base_context, add_nested_context, apply_context_config, base_context_key, context_value, default_redact_keys, redact_sensitive_values,
+    remove_nulls, reset_global_context, set_correlation_id, ContextConfig, ContextKey, HttpRequest, HttpResponse, TelemetryFields, User, CONFIG_FULL,
+    CONFIG_MINIMAL,
 };
 use crate::env::{is_build, is_local};
 use crate::error::{log_error, LoggedError};
@@ -80,6 +81,9 @@ pub struct LoggerOptions {
     pub log_to_file: Option<bool>,
     pub rotation: Option<RotationOptions>,
     pub config_settings: Option<HashMap<String, ContextConfig>>,
+    /// Optional override for the redact-keys list. When `None`, defaults from
+    /// [`default_redact_keys`] are used.
+    pub redact_keys: Option<Vec<String>>,
 }
 
 fn default_config_settings() -> HashMap<String, ContextConfig> {
@@ -99,6 +103,7 @@ pub struct Logger {
     log_to_file: bool,
     rotation: RotationOptions,
     file_writer: Option<Arc<RotatingFileWriter>>,
+    redact_keys: std::collections::HashSet<String>,
 }
 
 impl Default for Logger {
@@ -149,6 +154,13 @@ impl Logger {
             }
         }
 
+        let redact_keys = options
+            .redact_keys
+            .unwrap_or_else(default_redact_keys)
+            .into_iter()
+            .map(|k| k.to_lowercase())
+            .collect();
+
         Self {
             name,
             level,
@@ -158,6 +170,31 @@ impl Logger {
             log_to_file: file_writer.is_some(),
             rotation,
             file_writer,
+            redact_keys,
+        }
+    }
+
+    /// Returns the current redact-keys list (lowercased).
+    pub fn redact_keys(&self) -> Vec<String> {
+        let mut keys: Vec<String> = self.redact_keys.iter().cloned().collect();
+        keys.sort();
+        keys
+    }
+
+    /// Replaces the redact-keys list. Keys are stored lowercased; matching is
+    /// case-insensitive.
+    pub fn set_redact_keys(&mut self, keys: Vec<String>) {
+        self.redact_keys = keys.into_iter().map(|k| k.to_lowercase()).collect();
+    }
+
+    /// Adds keys to the existing redact list.
+    pub fn add_redact_keys<I, S>(&mut self, keys: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        for key in keys {
+            self.redact_keys.insert(key.into().to_lowercase());
         }
     }
 
@@ -355,6 +392,8 @@ impl Logger {
         if let Some(config) = &self.context_config {
             payload = apply_context_config(&payload, config);
         }
+
+        redact_sensitive_values(&mut payload, &self.redact_keys);
 
         payload
     }
@@ -723,5 +762,55 @@ mod tests {
         let http = payload.get("http").unwrap().as_object().unwrap().get("request").unwrap().as_object().unwrap();
         assert!(http.get("body").is_none());
         assert!(http.get("method").is_some());
+    }
+
+    #[test]
+    fn redact_default_keys_strips_auth_headers_and_secret_fields() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let logger = Logger::default();
+        logger.reset_context();
+        logger.add_base_context(json!({
+            "http": {
+                "request": {
+                    "headers": {
+                        "Authorization": "Bearer super-secret",
+                        "Cookie": "session=abc",
+                        "x-api-key": "k_xxx",
+                        "User-Agent": "smoo/1.0"
+                    }
+                }
+            },
+            "user": {
+                "password": "hunter2",
+                "client_secret": "cs",
+                "visible": "ok"
+            }
+        }));
+        let payload = logger.build_log_object(Level::Info, &log_args!("hi"));
+        let headers = payload.pointer("/http/request/headers").and_then(|v| v.as_object()).unwrap();
+        assert_eq!(headers.get("Authorization").unwrap(), "[REDACTED]");
+        assert_eq!(headers.get("Cookie").unwrap(), "[REDACTED]");
+        assert_eq!(headers.get("x-api-key").unwrap(), "[REDACTED]");
+        assert_eq!(headers.get("User-Agent").unwrap(), "smoo/1.0");
+
+        let user = payload.pointer("/user").and_then(|v| v.as_object()).unwrap();
+        assert_eq!(user.get("password").unwrap(), "[REDACTED]");
+        assert_eq!(user.get("client_secret").unwrap(), "[REDACTED]");
+        assert_eq!(user.get("visible").unwrap(), "ok");
+    }
+
+    #[test]
+    fn add_redact_keys_extends_default_list() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        let mut logger = Logger::default();
+        logger.reset_context();
+        logger.add_redact_keys(["customSecret".to_string()]);
+        logger.add_base_context(json!({
+            "context": {"customSecret": "shh", "visible": "ok"}
+        }));
+        let payload = logger.build_log_object(Level::Info, &log_args!());
+        let ctx = payload.pointer("/context").and_then(|v| v.as_object()).unwrap();
+        assert_eq!(ctx.get("customSecret").unwrap(), "[REDACTED]");
+        assert_eq!(ctx.get("visible").unwrap(), "ok");
     }
 }

--- a/src/Logger.spec.ts
+++ b/src/Logger.spec.ts
@@ -354,4 +354,88 @@ describe("Test Logger", () => {
     expect(loggedObject[ContextKey.ErrorDetails]).toHaveLength(2);
     expect(loggedObject[ContextKey.Message]).toBe("Additional message");
   });
+
+  describe("redaction", () => {
+    test("redacts default sensitive HTTP headers in request context", () => {
+      logger.resetContext();
+      const mockRequest = {
+        url: "https://example.com/api/resource",
+        method: "POST",
+        headers: new Headers({
+          authorization: "Bearer super-secret-token",
+          cookie: "session=abc123",
+          "x-api-key": "k_xxxxxxxxxxxx",
+          "x-amz-security-token": "AQoDY...",
+          "user-agent": "smoo-test/1.0",
+        }),
+      } as any;
+
+      logger.addRequestContext(mockRequest);
+
+      const logSpy = vi.spyOn(logger as any, "logFunc") as any;
+      logger.info("request received");
+
+      const loggedObject = logSpy.mock.calls[0][0][0] as any;
+      const headers = loggedObject[ContextKey.Http]?.request?.headers;
+      expect(headers).toBeDefined();
+      expect(headers.authorization).toBe("[REDACTED]");
+      expect(headers.cookie).toBe("[REDACTED]");
+      expect(headers["x-api-key"]).toBe("[REDACTED]");
+      expect(headers["x-amz-security-token"]).toBe("[REDACTED]");
+      // Non-sensitive headers preserved
+      expect(headers["user-agent"]).toBe("smoo-test/1.0");
+    });
+
+    test("redacts password/secret-like field names case-insensitively", () => {
+      logger.resetContext();
+      const logSpy = vi.spyOn(logger as any, "logFunc") as any;
+      logger.info({
+        Password: "hunter2",
+        api_key: "sk_xxxxxxxx",
+        refreshToken: "rt-1",
+        refresh_token: "rt-2",
+        client_secret: "cs_xxx",
+        normalField: "ok",
+      });
+
+      const loggedObject = logSpy.mock.calls[0][0][0] as any;
+      const ctx = loggedObject[ContextKey.Context];
+      expect(ctx.Password).toBe("[REDACTED]");
+      expect(ctx.api_key).toBe("[REDACTED]");
+      expect(ctx.refresh_token).toBe("[REDACTED]");
+      expect(ctx.client_secret).toBe("[REDACTED]");
+      expect(ctx.normalField).toBe("ok");
+      // `refreshToken` (camelCase) is NOT in the default list — only `refresh_token`
+      // and `access_token`. Validate that camelCase isn't redacted by default.
+      expect(ctx.refreshToken).toBe("rt-1");
+    });
+
+    test("addRedactKeys extends the redact list", () => {
+      logger.resetContext();
+      logger.addRedactKeys(["customSecret"]);
+      const logSpy = vi.spyOn(logger as any, "logFunc") as any;
+      logger.info({ customSecret: "shh", visible: "ok" });
+
+      const loggedObject = logSpy.mock.calls[0][0][0] as any;
+      const ctx = loggedObject[ContextKey.Context];
+      expect(ctx.customSecret).toBe("[REDACTED]");
+      expect(ctx.visible).toBe("ok");
+    });
+
+    test("redactKeys constructor option overrides defaults", () => {
+      const customLogger = new TestLogger({
+        context: {},
+        level: Level.Info,
+        redactKeys: ["onlyThis"],
+      });
+      const logSpy = vi.spyOn(customLogger as any, "logFunc") as any;
+      customLogger.info({ onlyThis: "x", authorization: "Bearer plaintext-leak" });
+
+      const loggedObject = logSpy.mock.calls[0][0][0] as any;
+      const ctx = loggedObject[ContextKey.Context];
+      expect(ctx.onlyThis).toBe("[REDACTED]");
+      // With overridden list, default `authorization` is NOT redacted
+      expect(ctx.authorization).toBe("Bearer plaintext-leak");
+    });
+  });
 });

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -228,7 +228,39 @@ export const CONFIG_MINIMAL: ContextConfig = {
 
 export const CONFIG_FULL: ContextConfig = null;
 
+/**
+ * Default list of context keys whose values should be redacted before logging.
+ * Matches case-insensitively against any key in the serialized log object —
+ * including HTTP request/response headers, body fields, query params, etc.
+ *
+ * The redacted value is replaced with the string `"[REDACTED]"`.
+ */
+export const DEFAULT_REDACT_KEYS: string[] = [
+  // Auth-bearing HTTP headers
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "x-amz-security-token",
+  // Common credential / token field names
+  "password",
+  "passwd",
+  "secret",
+  "apikey",
+  "api_key",
+  "token",
+  "access_token",
+  "refresh_token",
+  "client_secret",
+];
+
+export const REDACTED_VALUE = "[REDACTED]";
+
 export default class Logger {
+  public static DEFAULT_REDACT_KEYS: string[] = DEFAULT_REDACT_KEYS;
+  public static REDACTED_VALUE: string = REDACTED_VALUE;
+
   private _name = "Logger";
   private _level: Level = Level.Info;
   private _contextConfig!: ContextConfig;
@@ -240,6 +272,9 @@ export default class Logger {
   private prettyPrint = false;
   private rotation!: RotationOptions;
   private logToFile = false;
+  private _redactKeys: Set<string> = new Set(
+    Logger.DEFAULT_REDACT_KEYS.map((k) => k.toLowerCase()),
+  );
 
   public get name(): string {
     return this._name;
@@ -317,6 +352,56 @@ export default class Logger {
     return this.levelToCode(limit) >= this.levelToCode(this.level);
   }
 
+  /**
+   * Returns the current list of redact keys (lowercased).
+   */
+  public get redactKeys(): string[] {
+    return Array.from(this._redactKeys);
+  }
+
+  /**
+   * Replaces the redact-keys list. Keys are stored lowercased and matched
+   * case-insensitively against any field in the serialized log object.
+   */
+  public set redactKeys(keys: string[]) {
+    this._redactKeys = new Set(keys.map((k) => k.toLowerCase()));
+  }
+
+  /**
+   * Adds keys to the redact list. Existing entries are preserved.
+   * @param keys Keys to redact. Matching is case-insensitive.
+   */
+  public addRedactKeys(keys: string[]): void {
+    for (const key of keys) {
+      this._redactKeys.add(key.toLowerCase());
+    }
+  }
+
+  /**
+   * Recursively walks an object and replaces values for any key matching the
+   * redact list (case-insensitive) with `"[REDACTED]"`.
+   */
+  protected redactSensitiveValues(obj: any): any {
+    if (this._redactKeys.size === 0) return obj;
+    if (obj === null || obj === undefined) return obj;
+    if (Array.isArray(obj)) {
+      return obj.map((v) => this.redactSensitiveValues(v));
+    }
+    if (typeof obj !== "object") return obj;
+
+    const out: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+      if (this._redactKeys.has(key.toLowerCase())) {
+        out[key] = REDACTED_VALUE;
+      } else if (value && typeof value === "object") {
+        out[key] = this.redactSensitiveValues(value);
+      } else {
+        out[key] = value;
+      }
+    }
+    return out;
+  }
+
   protected removeUndefinedValuesRecursively(obj: any): any {
     if (!obj) return obj;
 
@@ -348,9 +433,13 @@ export default class Logger {
       prettyPrint?: boolean;
       logToFile?: boolean;
       rotation?: RotationOptions;
+      redactKeys?: string[];
     } = {},
   ) {
     options.name = options.name ?? this.name;
+    if (options.redactKeys) {
+      this.redactKeys = options.redactKeys;
+    }
     options.level = options.level ?? this.parseLevel(process.env.LOG_LEVEL);
     this.level = options.level;
     options.prettyPrint = options.prettyPrint ?? (isLocal() || isBuild());
@@ -731,7 +820,11 @@ export default class Logger {
     object[ContextKey.LogLevel] = level;
     object[ContextKey.Time] = dayjs().toISOString();
     object[ContextKey.Name] = this.name;
-    return [this.removeUndefinedValuesRecursively(this.applyContextConfig(object))];
+    return [
+      this.redactSensitiveValues(
+        this.removeUndefinedValuesRecursively(this.applyContextConfig(object)),
+      ),
+    ];
   }
 
   private prettyStringify(object: any): string {


### PR DESCRIPTION
## Summary
- Adds case-insensitive sensitive-field redaction to all five logger ports (TS, Python, Rust, Go, .NET) — values for known auth/credential keys are replaced with `[REDACTED]` before logs are written.
- Default list covers HTTP auth headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, `x-amz-security-token`, `proxy-authorization`) and credential-shaped field names (`password`, `passwd`, `secret`, `apiKey`, `api_key`, `token`, `access_token`, `refresh_token`, `client_secret`).
- Every port exposes `addRedactKeys` / `AddRedactKeys` / `add_redact_keys` to extend, plus a constructor option to override defaults entirely (empty list disables redaction).

## Why
Previously every port serialized HTTP request headers and request bodies directly into structured logs with no filtering. `Authorization: Bearer xyz`, `Cookie: session=...`, and `password: "hunter2"` all landed in CloudWatch / log shipping pipelines verbatim — permanent leaks. This is the biggest single security gap in `@smooai/logger`.

## Test plan
- [x] TS — vitest covers default header redaction, secret field names (case-insensitive), `addRedactKeys` extension, constructor override
- [x] Python — pytest covers the same matrix
- [x] Rust — cargo test covers default redaction and `add_redact_keys`
- [x] Go — go test covers all three matrices
- [x] .NET — xunit covers all four matrices (header, field-name, extend, override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)