### PR TITLE
SMOODEV-943: Rust — add AWS Lambda/SQS/API Gateway/ECS context helpers

### DIFF
--- a/.changeset/smoodev-943-rust-aws-context.md
+++ b/.changeset/smoodev-943-rust-aws-context.md
@@ -1,0 +1,5 @@
+---
+"@smooai/logger": patch
+---
+
+SMOODEV-943: Rust port — implement AWS Lambda/SQS/API Gateway/ECS context helpers. Adds a new `aws` module with an `AwsContextLogger` trait that mirrors the Go `LambdaLogger` and Python `AwsServerLogger` surfaces — `add_lambda_context`, `add_lambda_environment_context`, `add_sqs_record_context`, `add_api_gateway_context`, `add_ecs_context`. Lambda/SQS/API Gateway methods are gated behind an opt-in `aws-lambda` cargo feature (which pulls in `lambda_runtime` and `aws_lambda_events`) so consumers that don't need the AWS bindings aren't forced to compile them. ECS context (`add_ecs_context`, `ecs_environment_context`) is env-var-only and always available. Previously `rust/logger/src/lib.rs` only exposed the base `Logger` — the README marketed Lambda + SQS + API Gateway support but the implementation was missing.

--- a/rust/logger/Cargo.lock
+++ b/rust/logger/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +21,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws_lambda_events"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144ec7565561115498a288850cc6a42b279e09b6c4b88f623eecb9c8ca96c08c"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-serde",
+ "query_map",
+ "serde",
+ "serde_json",
+ "serde_with",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -24,10 +84,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -76,6 +154,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +207,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -124,6 +252,94 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,14 +348,115 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f056c8559e3757392c8d091e796416e4649d8e49e88b8d76df6c002f05027fd"
+dependencies = [
+ "http",
+ "serde",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -252,6 +569,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,12 +597,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -296,6 +632,55 @@ checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lambda_runtime"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed49669d6430292aead991e19bf13153135a884f916e68f32997c951af637ebe"
+dependencies = [
+ "async-stream",
+ "base64",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-serde",
+ "hyper",
+ "hyper-util",
+ "lambda_runtime_api_client",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tracing",
+]
+
+[[package]]
+name = "lambda_runtime_api_client"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c90a10f094475a34a04da2be11686c4dcfe214d93413162db9ffdff3d3af293a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -339,10 +724,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -389,6 +800,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,12 +835,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "query_map"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eab6b8b1074ef3359a863758dae650c7c0c6027927a085b7af911c8e0bf3a15"
+dependencies = [
+ "form_urlencoded",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -431,6 +885,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +945,30 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "scopeguard"
@@ -497,7 +1012,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
@@ -506,10 +1021,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.11.4",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -521,8 +1094,10 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 name = "smooai-logger"
 version = "3.1.2"
 dependencies = [
+ "aws_lambda_events",
  "chrono",
  "colored",
+ "lambda_runtime",
  "once_cell",
  "parking_lot",
  "serde",
@@ -533,10 +1108,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -574,6 +1165,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +1213,152 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-serde",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -617,6 +1394,27 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"

--- a/rust/logger/Cargo.toml
+++ b/rust/logger/Cargo.toml
@@ -10,6 +10,15 @@ keywords = ["logging", "structured-logging", "smooai", "observability", "context
 categories = ["development-tools::debugging"]
 readme = "README.md"
 
+[features]
+default = []
+# Enables the AWS Lambda / SQS / API Gateway / ECS context helpers in
+# [`crate::aws`]. Pulls in `lambda_runtime` and `aws_lambda_events` and is
+# off by default so consumers that don't need AWS bindings aren't forced
+# to compile them. `ecs` context helpers also work without this feature
+# enabled — they read env vars only.
+aws-lambda = ["dep:lambda_runtime", "dep:aws_lambda_events"]
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
@@ -19,6 +28,11 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde", "clock"] }
 colored = "2"
 url = "2"
+lambda_runtime = { version = "0.13", optional = true }
+aws_lambda_events = { version = "0.16", default-features = false, features = [
+  "apigw",
+  "sqs",
+], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/logger/src/aws.rs
+++ b/rust/logger/src/aws.rs
@@ -1,0 +1,352 @@
+//! AWS context helpers — Lambda, API Gateway, SQS, ECS.
+//!
+//! Mirrors the Go (`go/lambda.go`) and Python (`python/src/smooai_logger/aws_logger.py`)
+//! ports' AwsServerLogger surface. Adds invocation/event metadata to the logger's
+//! base context so it lands in CloudWatch alongside every structured log entry.
+//!
+//! ## Feature gates
+//!
+//! Lambda / SQS / API Gateway helpers depend on the AWS event types from
+//! [`lambda_runtime`] and [`aws_lambda_events`], so they're gated behind the
+//! `aws-lambda` cargo feature.
+//!
+//! ECS context helpers ([`ecs_environment_context`] / [`AwsContextLogger::add_ecs_context`])
+//! read env vars only and are always available.
+//!
+//! ## Example
+//!
+//! ```no_run
+//! use smooai_logger::{Logger, aws::AwsContextLogger};
+//!
+//! let logger = Logger::default();
+//! logger.add_ecs_context();
+//! let _ = logger.info("running in ECS");
+//! ```
+
+use serde_json::{json, Map, Value};
+
+use crate::context::add_base_context;
+use crate::logger::Logger;
+
+/// Captures `AWS_LAMBDA_FUNCTION_NAME` / `AWS_LAMBDA_FUNCTION_VERSION` /
+/// `AWS_EXECUTION_ENV` / `AWS_LAMBDA_LOG_GROUP_NAME` / `AWS_LAMBDA_LOG_STREAM_NAME` /
+/// `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` / `AWS_REGION` / `NODE_ENV` env vars into
+/// a structured value, ready to merge under `lambda` and top-level region/env keys.
+pub fn lambda_environment_context() -> Value {
+    let mut lambda = Map::new();
+    if let Ok(v) = std::env::var("AWS_LAMBDA_FUNCTION_NAME") {
+        lambda.insert("functionName".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("AWS_LAMBDA_FUNCTION_VERSION") {
+        lambda.insert("functionVersion".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("AWS_EXECUTION_ENV") {
+        lambda.insert("executionEnvironment".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("AWS_LAMBDA_LOG_GROUP_NAME") {
+        lambda.insert("logGroupName".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("AWS_LAMBDA_LOG_STREAM_NAME") {
+        lambda.insert("logStreamName".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("AWS_LAMBDA_FUNCTION_MEMORY_SIZE") {
+        lambda.insert("functionMemorySize".into(), Value::String(v));
+    }
+
+    let mut root = Map::new();
+    if !lambda.is_empty() {
+        root.insert("lambda".into(), Value::Object(lambda));
+    }
+    if let Ok(v) = std::env::var("AWS_REGION").or_else(|_| std::env::var("AWS_DEFAULT_REGION")) {
+        root.insert("region".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("NODE_ENV") {
+        root.insert("nodeEnv".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("NODE_CONFIG_ENV") {
+        root.insert("nodeConfigEnv".into(), Value::String(v));
+    }
+    Value::Object(root)
+}
+
+/// Captures Amazon ECS / Fargate env vars into an `ecs` context object.
+///
+/// Reads: `ECS_CONTAINER_METADATA_URI_V4`, `ECS_CONTAINER_METADATA_URI`,
+/// `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, `ECS_AGENT_URI`,
+/// `AWS_EXECUTION_ENV`, `AWS_DEFAULT_REGION`, `AWS_REGION`.
+pub fn ecs_environment_context() -> Value {
+    let mut ecs = Map::new();
+    if let Ok(v) = std::env::var("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") {
+        ecs.insert("containerCredentialsRelativeUri".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("ECS_CONTAINER_METADATA_URI_V4") {
+        ecs.insert("containerMetadataUriV4".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("ECS_CONTAINER_METADATA_URI") {
+        ecs.insert("containerMetadataUri".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("ECS_AGENT_URI") {
+        ecs.insert("agentUri".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("AWS_EXECUTION_ENV") {
+        ecs.insert("executionEnv".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("AWS_DEFAULT_REGION") {
+        ecs.insert("defaultRegion".into(), Value::String(v));
+    }
+    if let Ok(v) = std::env::var("AWS_REGION") {
+        ecs.insert("region".into(), Value::String(v));
+    }
+    json!({ "ecs": Value::Object(ecs) })
+}
+
+/// AWS context extension methods on [`Logger`]. Provides parity with the
+/// Go `LambdaLogger` and Python `AwsServerLogger` surfaces.
+pub trait AwsContextLogger {
+    /// Attach Lambda environment vars (function name, version, log group, etc.)
+    /// to the logger's base context. Works regardless of the `aws-lambda` feature.
+    fn add_lambda_environment_context(&self);
+
+    /// Attach ECS / Fargate task metadata to the logger's base context under `ecs`.
+    /// Works regardless of the `aws-lambda` feature.
+    fn add_ecs_context(&self);
+
+    /// Attach Lambda invocation context (requestId, function ARN, etc.) plus
+    /// the environment context to the logger's base context. Requires the
+    /// `aws-lambda` feature.
+    #[cfg(feature = "aws-lambda")]
+    fn add_lambda_context(&self, ctx: &lambda_runtime::Context);
+
+    /// Attach SQS record context (messageId, eventSource, eventSourceArn) plus
+    /// any string message attributes to the logger's base context under `sqs`.
+    /// Also sets the correlation ID to the SQS message ID. Requires the
+    /// `aws-lambda` feature.
+    #[cfg(feature = "aws-lambda")]
+    fn add_sqs_record_context(&self, record: &aws_lambda_events::sqs::SqsMessage);
+
+    /// Attach API Gateway proxy request context (route, method, path, headers)
+    /// to the logger's base context, mirroring `addLambdaContext` in the TS port.
+    /// Requires the `aws-lambda` feature.
+    #[cfg(feature = "aws-lambda")]
+    fn add_api_gateway_context(&self, request: &aws_lambda_events::apigw::ApiGatewayProxyRequest);
+}
+
+impl AwsContextLogger for Logger {
+    fn add_lambda_environment_context(&self) {
+        let env_ctx = lambda_environment_context();
+        if let Value::Object(map) = &env_ctx {
+            if map.is_empty() {
+                return;
+            }
+        }
+        add_base_context(&env_ctx);
+    }
+
+    fn add_ecs_context(&self) {
+        let ecs_ctx = ecs_environment_context();
+        if let Some(inner) = ecs_ctx.get("ecs").and_then(|v| v.as_object()) {
+            if inner.is_empty() {
+                return;
+            }
+        }
+        add_base_context(&ecs_ctx);
+    }
+
+    #[cfg(feature = "aws-lambda")]
+    fn add_lambda_context(&self, ctx: &lambda_runtime::Context) {
+        let mut lambda = Map::new();
+        if !ctx.request_id.is_empty() {
+            lambda.insert("requestId".into(), Value::String(ctx.request_id.clone()));
+        }
+        if !ctx.invoked_function_arn.is_empty() {
+            lambda.insert("functionArn".into(), Value::String(ctx.invoked_function_arn.clone()));
+        }
+        if let Some(trace_id) = ctx.xray_trace_id.as_ref() {
+            if !trace_id.is_empty() {
+                lambda.insert("xrayTraceId".into(), Value::String(trace_id.clone()));
+            }
+        }
+
+        let mut root = Map::new();
+        root.insert("lambda".into(), Value::Object(lambda));
+        add_base_context(&Value::Object(root));
+
+        // Merge environment context on top
+        self.add_lambda_environment_context();
+
+        // Use the Lambda request ID as the correlation ID
+        if !ctx.request_id.is_empty() {
+            self.set_correlation_id(&ctx.request_id);
+        }
+    }
+
+    #[cfg(feature = "aws-lambda")]
+    fn add_sqs_record_context(&self, record: &aws_lambda_events::sqs::SqsMessage) {
+        let mut sqs = Map::new();
+        if let Some(id) = &record.message_id {
+            sqs.insert("messageId".into(), Value::String(id.clone()));
+        }
+        if let Some(src) = &record.event_source {
+            sqs.insert("eventSource".into(), Value::String(src.clone()));
+        }
+        if let Some(arn) = &record.event_source_arn {
+            sqs.insert("eventSourceArn".into(), Value::String(arn.clone()));
+        }
+        if let Some(handle) = &record.receipt_handle {
+            sqs.insert("receiptHandle".into(), Value::String(handle.clone()));
+        }
+
+        // String-valued message attributes (skip Binary)
+        let mut attrs = Map::new();
+        for (k, attr) in record.message_attributes.iter() {
+            if let Some(s) = &attr.string_value {
+                attrs.insert(k.clone(), Value::String(s.clone()));
+            }
+        }
+        if !attrs.is_empty() {
+            sqs.insert("attributes".into(), Value::Object(attrs));
+        }
+
+        let mut root = Map::new();
+        root.insert("sqs".into(), Value::Object(sqs));
+        add_base_context(&Value::Object(root));
+
+        if let Some(id) = &record.message_id {
+            if !id.is_empty() {
+                self.set_correlation_id(id);
+            }
+        }
+    }
+
+    #[cfg(feature = "aws-lambda")]
+    fn add_api_gateway_context(&self, request: &aws_lambda_events::apigw::ApiGatewayProxyRequest) {
+        let mut http_request = Map::new();
+        http_request.insert("method".into(), Value::String(request.http_method.as_str().to_string()));
+        if let Some(path) = &request.path {
+            http_request.insert("path".into(), Value::String(path.clone()));
+        }
+
+        // Headers — aws_lambda_events uses HeaderMap; flatten string-valued entries.
+        let mut headers = Map::new();
+        for (key, value) in request.headers.iter() {
+            if let Ok(v) = value.to_str() {
+                headers.insert(key.as_str().to_string(), Value::String(v.to_string()));
+            }
+        }
+        if !headers.is_empty() {
+            http_request.insert("headers".into(), Value::Object(headers));
+        }
+
+        // API Gateway-specific bag
+        let mut apigw = Map::new();
+        if let Some(rid) = &request.request_context.request_id {
+            if !rid.is_empty() {
+                apigw.insert("requestId".into(), Value::String(rid.clone()));
+            }
+        }
+        if let Some(stage) = &request.request_context.stage {
+            apigw.insert("stage".into(), Value::String(stage.clone()));
+        }
+        if let Some(api_id) = &request.request_context.apiid {
+            if !api_id.is_empty() {
+                apigw.insert("apiId".into(), Value::String(api_id.clone()));
+            }
+        }
+
+        let mut root = Map::new();
+        if !http_request.is_empty() {
+            let mut http = Map::new();
+            http.insert("request".into(), Value::Object(http_request));
+            root.insert("http".into(), Value::Object(http));
+        }
+        if !apigw.is_empty() {
+            root.insert("apiGateway".into(), Value::Object(apigw));
+        }
+        if !root.is_empty() {
+            add_base_context(&Value::Object(root));
+        }
+
+        if let Some(rid) = &request.request_context.request_id {
+            if !rid.is_empty() {
+                self.set_correlation_id(rid);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::reset_global_context;
+    use crate::logger::Logger;
+    use std::sync::Mutex;
+
+    /// Env-var-modifying tests must hold this lock; std::env::set_var is not
+    /// thread-safe and Rust tests run in parallel by default.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn add_ecs_context_picks_up_env_vars() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_global_context();
+        // SAFETY: protected by ENV_LOCK above.
+        unsafe {
+            std::env::set_var("ECS_CONTAINER_METADATA_URI_V4", "http://169.254.170.2/v4/abc");
+            std::env::set_var("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE");
+            std::env::set_var("AWS_REGION", "us-east-1");
+        }
+
+        let logger = Logger::default();
+        logger.add_ecs_context();
+        let ctx = logger.context();
+        let ecs = ctx
+            .as_object()
+            .and_then(|m| m.get("ecs"))
+            .and_then(|v| v.as_object())
+            .expect("ecs context not set");
+        assert_eq!(ecs.get("containerMetadataUriV4").unwrap(), "http://169.254.170.2/v4/abc");
+        assert_eq!(ecs.get("executionEnv").unwrap(), "AWS_ECS_FARGATE");
+        assert_eq!(ecs.get("region").unwrap(), "us-east-1");
+
+        // SAFETY: protected by ENV_LOCK above.
+        unsafe {
+            std::env::remove_var("ECS_CONTAINER_METADATA_URI_V4");
+            std::env::remove_var("AWS_EXECUTION_ENV");
+            std::env::remove_var("AWS_REGION");
+        }
+    }
+
+    #[test]
+    fn add_lambda_environment_context_reads_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        reset_global_context();
+        // SAFETY: protected by ENV_LOCK above.
+        unsafe {
+            std::env::set_var("AWS_LAMBDA_FUNCTION_NAME", "test-fn");
+            std::env::set_var("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST");
+            std::env::set_var("AWS_LAMBDA_LOG_GROUP_NAME", "/aws/lambda/test-fn");
+            std::env::set_var("AWS_REGION", "us-west-2");
+        }
+
+        let logger = Logger::default();
+        logger.add_lambda_environment_context();
+        let ctx = logger.context();
+        let lambda = ctx
+            .as_object()
+            .and_then(|m| m.get("lambda"))
+            .and_then(|v| v.as_object())
+            .expect("lambda context not set");
+        assert_eq!(lambda.get("functionName").unwrap(), "test-fn");
+        assert_eq!(lambda.get("functionVersion").unwrap(), "$LATEST");
+        assert_eq!(lambda.get("logGroupName").unwrap(), "/aws/lambda/test-fn");
+        assert_eq!(ctx.as_object().unwrap().get("region").unwrap(), "us-west-2");
+
+        // SAFETY: protected by ENV_LOCK above.
+        unsafe {
+            std::env::remove_var("AWS_LAMBDA_FUNCTION_NAME");
+            std::env::remove_var("AWS_LAMBDA_FUNCTION_VERSION");
+            std::env::remove_var("AWS_LAMBDA_LOG_GROUP_NAME");
+            std::env::remove_var("AWS_REGION");
+        }
+    }
+}

--- a/rust/logger/src/lib.rs
+++ b/rust/logger/src/lib.rs
@@ -4,6 +4,7 @@
 //! `@smooai/logger`, offering structured contextual logging, correlation tracking, and
 //! optional file rotation with pretty-printed output.
 
+pub mod aws;
 pub mod context;
 pub mod env;
 pub mod error;


### PR DESCRIPTION
## Summary
- Adds a new `aws` module to the Rust port with an `AwsContextLogger` trait that mirrors Go (`go/lambda.go`) and Python (`python/src/smooai_logger/aws_logger.py`) AwsServerLogger surfaces.
- Methods: `add_lambda_context`, `add_lambda_environment_context`, `add_sqs_record_context`, `add_api_gateway_context`, `add_ecs_context`.
- Lambda / SQS / API Gateway helpers are gated behind an opt-in `aws-lambda` cargo feature (pulls in `lambda_runtime` + `aws_lambda_events`). ECS helpers are env-var-only and always available.

## Why
`rust/logger/src/lib.rs` previously only exposed the base `Logger` — the README marketed Lambda + SQS + API Gateway support but the implementation was missing. This unblocks Rust services from getting the same first-class invocation/event context the Go and Python ports already have.

## Test plan
- [x] `cargo test` (no features) — ecs + lambda-env tests pass via env-var setup
- [x] `cargo test --all-features` — same plus the gated Lambda/SQS/APIGW trait methods compile cleanly against the real `lambda_runtime` 0.13 / `aws_lambda_events` 0.16 types
- [x] `cargo check --all-targets --all-features` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)