### PR TITLE
SMOODEV-944: .NET — add AwsServerLogger with Lambda/SQS/APIGW/ECS context

### DIFF
--- a/.changeset/smoodev-944-dotnet-aws-context.md
+++ b/.changeset/smoodev-944-dotnet-aws-context.md
@@ -1,0 +1,5 @@
+---
+"@smooai/logger": patch
+---
+
+SMOODEV-944: .NET port — implement `AwsServerLogger` with Lambda / SQS / API Gateway / ECS context helpers. New `SmooAI.Logger.AwsServerLogger` (extends `SmooLogger`) adds `AddLambdaContext(ILambdaContext)`, `AddLambdaEnvironmentContext()`, `AddSqsRecordContext(SQSEvent.SQSMessage)`, `AddApiGatewayContext(APIGatewayProxyRequest)`, and `AddECSContext()`. Mirrors the TS `AwsServerLogger`, Python `AwsServerLogger`, and Go `LambdaLogger` surfaces. NuGet deps added to `SmooAI.Logger`: `Amazon.Lambda.Core`, `Amazon.Lambda.SQSEvents`, `Amazon.Lambda.APIGatewayEvents` — small, version-stable interface packages every .NET Lambda project pulls in anyway. File rotation parity (TS `RotationOptions`) is intentionally deferred to a follow-up; the AWS context surface is the bigger gap.

--- a/dotnet/src/SmooAI.Logger/AwsServerLogger.cs
+++ b/dotnet/src/SmooAI.Logger/AwsServerLogger.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+
+namespace SmooAI.Logger;
+
+/// <summary>
+/// Lambda / ECS / SQS / API Gateway context helpers on top of <see cref="SmooLogger"/>.
+/// Mirrors the TS <c>AwsServerLogger</c>, Python <c>AwsServerLogger</c>, and Go
+/// <c>LambdaLogger</c> ports — call the appropriate <c>Add*Context</c> method
+/// inside your Lambda handler and the invocation/event metadata lands on every
+/// log entry until the context is reset.
+/// </summary>
+public class AwsServerLogger : SmooLogger
+{
+    public AwsServerLogger() : this(new SmooLoggerOptions { Name = "AwsServerLogger" }) { }
+
+    public AwsServerLogger(SmooLoggerOptions options) : base(options) { }
+
+    /// <summary>
+    /// Capture Lambda environment variables (function name, version, log group,
+    /// memory size, region, NODE_ENV) into the logger's base context.
+    /// </summary>
+    public void AddLambdaEnvironmentContext()
+    {
+        var lambdaBag = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        AddIfPresent(lambdaBag, "functionName", "AWS_LAMBDA_FUNCTION_NAME");
+        AddIfPresent(lambdaBag, "functionVersion", "AWS_LAMBDA_FUNCTION_VERSION");
+        AddIfPresent(lambdaBag, "executionEnv", "AWS_EXECUTION_ENV");
+        AddIfPresent(lambdaBag, "logGroupName", "AWS_LAMBDA_LOG_GROUP_NAME");
+        AddIfPresent(lambdaBag, "logStreamName", "AWS_LAMBDA_LOG_STREAM_NAME");
+        AddIfPresent(lambdaBag, "memorySizeMB", "AWS_LAMBDA_FUNCTION_MEMORY_SIZE");
+
+        var root = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        if (lambdaBag.Count > 0)
+        {
+            root["awsLambda"] = lambdaBag;
+        }
+        var region = System.Environment.GetEnvironmentVariable("AWS_DEFAULT_REGION")
+                     ?? System.Environment.GetEnvironmentVariable("AWS_REGION");
+        if (!string.IsNullOrEmpty(region)) root["region"] = region;
+        var nodeEnv = System.Environment.GetEnvironmentVariable("NODE_ENV");
+        if (!string.IsNullOrEmpty(nodeEnv)) root["nodeEnv"] = nodeEnv;
+
+        if (root.Count > 0)
+        {
+            AddBaseContext(root);
+        }
+    }
+
+    /// <summary>
+    /// Capture ECS / Fargate task metadata env vars under the <c>ecs</c> key.
+    /// Always safe to call — values absent in non-ECS environments are skipped.
+    /// </summary>
+    public void AddECSContext()
+    {
+        var ecs = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        AddIfPresent(ecs, "containerCredentialsRelativeUri", "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
+        AddIfPresent(ecs, "containerMetadataUriV4", "ECS_CONTAINER_METADATA_URI_V4");
+        AddIfPresent(ecs, "containerMetadataUri", "ECS_CONTAINER_METADATA_URI");
+        AddIfPresent(ecs, "agentUri", "ECS_AGENT_URI");
+        AddIfPresent(ecs, "executionEnv", "AWS_EXECUTION_ENV");
+        AddIfPresent(ecs, "defaultRegion", "AWS_DEFAULT_REGION");
+        AddIfPresent(ecs, "region", "AWS_REGION");
+
+        if (ecs.Count > 0)
+        {
+            AddBaseContext(new Dictionary<string, object?>(System.StringComparer.Ordinal)
+            {
+                ["ecs"] = ecs,
+            });
+        }
+    }
+
+    /// <summary>
+    /// Attach Lambda invocation context (AWS request ID, function ARN, remaining
+    /// time, identity) plus the environment context to the logger. Also sets
+    /// the correlation ID to the AWS request ID.
+    /// </summary>
+    public void AddLambdaContext(ILambdaContext context)
+    {
+        System.ArgumentNullException.ThrowIfNull(context);
+
+        var lambdaBag = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(context.AwsRequestId))
+            lambdaBag["requestId"] = context.AwsRequestId;
+        if (!string.IsNullOrEmpty(context.FunctionName))
+            lambdaBag["functionName"] = context.FunctionName;
+        if (!string.IsNullOrEmpty(context.FunctionVersion))
+            lambdaBag["functionVersion"] = context.FunctionVersion;
+        if (!string.IsNullOrEmpty(context.InvokedFunctionArn))
+            lambdaBag["functionArn"] = context.InvokedFunctionArn;
+        if (!string.IsNullOrEmpty(context.LogGroupName))
+            lambdaBag["logGroupName"] = context.LogGroupName;
+        if (!string.IsNullOrEmpty(context.LogStreamName))
+            lambdaBag["logStreamName"] = context.LogStreamName;
+        if (context.MemoryLimitInMB > 0)
+            lambdaBag["memorySizeMB"] = context.MemoryLimitInMB;
+        lambdaBag["remainingTimeMs"] = (long)context.RemainingTime.TotalMilliseconds;
+
+        AddBaseContext(new Dictionary<string, object?>(System.StringComparer.Ordinal)
+        {
+            ["awsLambda"] = lambdaBag,
+        });
+
+        AddLambdaEnvironmentContext();
+
+        if (!string.IsNullOrEmpty(context.AwsRequestId))
+        {
+            SetCorrelationId(context.AwsRequestId);
+        }
+    }
+
+    /// <summary>
+    /// Attach SQS record context (message ID, event source/ARN, receipt handle,
+    /// and string-valued message attributes) under the <c>sqs</c> key. Also sets
+    /// the correlation ID to the SQS message ID.
+    /// </summary>
+    public void AddSqsRecordContext(SQSEvent.SQSMessage record)
+    {
+        System.ArgumentNullException.ThrowIfNull(record);
+        var sqs = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(record.MessageId)) sqs["messageId"] = record.MessageId;
+        if (!string.IsNullOrEmpty(record.EventSource)) sqs["eventSource"] = record.EventSource;
+        if (!string.IsNullOrEmpty(record.EventSourceArn)) sqs["eventSourceArn"] = record.EventSourceArn;
+        if (!string.IsNullOrEmpty(record.ReceiptHandle)) sqs["receiptHandle"] = record.ReceiptHandle;
+
+        if (record.MessageAttributes != null && record.MessageAttributes.Count > 0)
+        {
+            var attrs = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+            foreach (var (key, attr) in record.MessageAttributes)
+            {
+                if (attr == null) continue;
+                if (!string.IsNullOrEmpty(attr.StringValue))
+                {
+                    attrs[key] = attr.StringValue;
+                }
+            }
+            if (attrs.Count > 0)
+            {
+                sqs["attributes"] = attrs;
+            }
+        }
+
+        AddBaseContext(new Dictionary<string, object?>(System.StringComparer.Ordinal)
+        {
+            ["sqs"] = sqs,
+        });
+
+        if (!string.IsNullOrEmpty(record.MessageId))
+        {
+            SetCorrelationId(record.MessageId);
+        }
+    }
+
+    /// <summary>
+    /// Attach API Gateway proxy request context (method, path, query string,
+    /// headers, source IP, user agent) and the API Gateway stage/requestId/apiId
+    /// to the logger. Also sets the correlation ID to the API Gateway request ID.
+    /// </summary>
+    public void AddApiGatewayContext(APIGatewayProxyRequest request)
+    {
+        System.ArgumentNullException.ThrowIfNull(request);
+        var http = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        if (!string.IsNullOrEmpty(request.HttpMethod)) http["method"] = request.HttpMethod;
+        if (!string.IsNullOrEmpty(request.Path)) http["path"] = request.Path;
+        if (request.RequestContext?.Identity != null)
+        {
+            if (!string.IsNullOrEmpty(request.RequestContext.Identity.SourceIp))
+                http["sourceIp"] = request.RequestContext.Identity.SourceIp;
+            if (!string.IsNullOrEmpty(request.RequestContext.Identity.UserAgent))
+                http["userAgent"] = request.RequestContext.Identity.UserAgent;
+        }
+        if (request.Headers != null && request.Headers.Count > 0)
+        {
+            http["headers"] = request.Headers.ToDictionary(kv => kv.Key, kv => (object?)kv.Value);
+        }
+        if (request.QueryStringParameters != null && request.QueryStringParameters.Count > 0)
+        {
+            var qs = string.Join("&", request.QueryStringParameters.Select(kv => $"{kv.Key}={kv.Value}"));
+            if (!string.IsNullOrEmpty(qs)) http["queryString"] = qs;
+        }
+        if (!string.IsNullOrEmpty(request.Body)) http["body"] = request.Body;
+
+        var apiGateway = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        if (request.RequestContext != null)
+        {
+            if (!string.IsNullOrEmpty(request.RequestContext.RequestId))
+                apiGateway["requestId"] = request.RequestContext.RequestId;
+            if (!string.IsNullOrEmpty(request.RequestContext.Stage))
+                apiGateway["stage"] = request.RequestContext.Stage;
+            if (!string.IsNullOrEmpty(request.RequestContext.ApiId))
+                apiGateway["apiId"] = request.RequestContext.ApiId;
+            if (!string.IsNullOrEmpty(request.RequestContext.ResourcePath))
+                apiGateway["resourcePath"] = request.RequestContext.ResourcePath;
+        }
+
+        var root = new Dictionary<string, object?>(System.StringComparer.Ordinal);
+        if (http.Count > 0)
+        {
+            root[ContextKey.Http] = new Dictionary<string, object?>(System.StringComparer.Ordinal)
+            {
+                ["request"] = http,
+            };
+        }
+        if (apiGateway.Count > 0)
+        {
+            root["apiGateway"] = apiGateway;
+        }
+        if (root.Count > 0)
+        {
+            AddBaseContext(root);
+        }
+
+        var correlationId = request.RequestContext?.RequestId;
+        if (!string.IsNullOrEmpty(correlationId))
+        {
+            SetCorrelationId(correlationId);
+        }
+    }
+
+    private static void AddIfPresent(Dictionary<string, object?> bag, string key, string envVar)
+    {
+        var value = System.Environment.GetEnvironmentVariable(envVar);
+        if (!string.IsNullOrEmpty(value))
+        {
+            bag[key] = value;
+        }
+    }
+}

--- a/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
+++ b/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
@@ -31,6 +31,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <!--
+      AWS Lambda event types — used by AwsServerLogger.cs. These are small,
+      version-stable interface packages widely used by .NET Lambda projects.
+      Adding them here means SmooAI.Logger consumers get Lambda/SQS/API
+      Gateway context helpers without an extra package install.
+    -->
+    <PackageReference Include="Amazon.Lambda.Core" Version="2.5.0" />
+    <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
+    <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/tests/SmooAI.Logger.Tests/AwsServerLoggerTests.cs
+++ b/dotnet/tests/SmooAI.Logger.Tests/AwsServerLoggerTests.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using Amazon.Lambda.APIGatewayEvents;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using SmooAI.Logger;
+
+namespace SmooAI.Logger.Tests;
+
+public class AwsServerLoggerTests
+{
+    private static (AwsServerLogger Logger, StringWriter Out) Build(Action<SmooLoggerOptions>? configure = null)
+    {
+        var writer = new StringWriter();
+        var opts = new SmooLoggerOptions { Output = writer, PrettyPrint = false, Name = "aws-test" };
+        configure?.Invoke(opts);
+        return (new AwsServerLogger(opts), writer);
+    }
+
+    private static JsonElement ParseSingle(string captured)
+    {
+        var line = captured.Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        return JsonDocument.Parse(line).RootElement;
+    }
+
+    [Fact]
+    public void AddECSContext_Reads_Env_Vars_Into_Ecs_Bag()
+    {
+        Environment.SetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4", "http://169.254.170.2/v4/abc");
+        Environment.SetEnvironmentVariable("AWS_EXECUTION_ENV", "AWS_ECS_FARGATE");
+        Environment.SetEnvironmentVariable("AWS_REGION", "us-east-1");
+        try
+        {
+            var (logger, writer) = Build();
+            logger.AddECSContext();
+            logger.LogInfo("running");
+            var entry = ParseSingle(writer.ToString());
+
+            var ecs = entry.GetProperty("ecs");
+            Assert.Equal("http://169.254.170.2/v4/abc", ecs.GetProperty("containerMetadataUriV4").GetString());
+            Assert.Equal("AWS_ECS_FARGATE", ecs.GetProperty("executionEnv").GetString());
+            Assert.Equal("us-east-1", ecs.GetProperty("region").GetString());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ECS_CONTAINER_METADATA_URI_V4", null);
+            Environment.SetEnvironmentVariable("AWS_EXECUTION_ENV", null);
+            Environment.SetEnvironmentVariable("AWS_REGION", null);
+        }
+    }
+
+    [Fact]
+    public void AddLambdaEnvironmentContext_Reads_Lambda_Env()
+    {
+        Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME", "test-fn");
+        Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST");
+        Environment.SetEnvironmentVariable("AWS_LAMBDA_LOG_GROUP_NAME", "/aws/lambda/test-fn");
+        Environment.SetEnvironmentVariable("AWS_REGION", "us-west-2");
+        try
+        {
+            var (logger, writer) = Build();
+            logger.AddLambdaEnvironmentContext();
+            logger.LogInfo("hi");
+            var entry = ParseSingle(writer.ToString());
+
+            var lambda = entry.GetProperty("awsLambda");
+            Assert.Equal("test-fn", lambda.GetProperty("functionName").GetString());
+            Assert.Equal("$LATEST", lambda.GetProperty("functionVersion").GetString());
+            Assert.Equal("/aws/lambda/test-fn", lambda.GetProperty("logGroupName").GetString());
+            Assert.Equal("us-west-2", entry.GetProperty("region").GetString());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_NAME", null);
+            Environment.SetEnvironmentVariable("AWS_LAMBDA_FUNCTION_VERSION", null);
+            Environment.SetEnvironmentVariable("AWS_LAMBDA_LOG_GROUP_NAME", null);
+            Environment.SetEnvironmentVariable("AWS_REGION", null);
+        }
+    }
+
+    [Fact]
+    public void AddLambdaContext_Captures_Invocation_Metadata_And_Correlation_Id()
+    {
+        var (logger, writer) = Build();
+        var lambdaContext = new TestLambdaContext
+        {
+            AwsRequestId = "req-abc-123",
+            FunctionName = "fn-x",
+            FunctionVersion = "42",
+            InvokedFunctionArn = "arn:aws:lambda:us-east-1:1234:function:fn-x",
+            LogGroupName = "/aws/lambda/fn-x",
+            LogStreamName = "stream-1",
+            MemoryLimitInMB = 256,
+            RemainingTime = TimeSpan.FromSeconds(30),
+        };
+        logger.AddLambdaContext(lambdaContext);
+        logger.LogInfo("invoked");
+        var entry = ParseSingle(writer.ToString());
+
+        var lambda = entry.GetProperty("awsLambda");
+        Assert.Equal("req-abc-123", lambda.GetProperty("requestId").GetString());
+        Assert.Equal("fn-x", lambda.GetProperty("functionName").GetString());
+        Assert.Equal("arn:aws:lambda:us-east-1:1234:function:fn-x", lambda.GetProperty("functionArn").GetString());
+        Assert.Equal("req-abc-123", entry.GetProperty("correlationId").GetString());
+    }
+
+    [Fact]
+    public void AddSqsRecordContext_Captures_Message_Metadata_And_Sets_Correlation_Id()
+    {
+        var (logger, writer) = Build();
+        var record = new SQSEvent.SQSMessage
+        {
+            MessageId = "msg-abc",
+            EventSource = "aws:sqs",
+            EventSourceArn = "arn:aws:sqs:us-east-1:1234:test-queue",
+            ReceiptHandle = "rh-xxx",
+            MessageAttributes = new Dictionary<string, SQSEvent.MessageAttribute>
+            {
+                ["CustomAttr"] = new SQSEvent.MessageAttribute { DataType = "String", StringValue = "value-1" },
+            },
+        };
+        logger.AddSqsRecordContext(record);
+        logger.LogInfo("sqs received");
+        var entry = ParseSingle(writer.ToString());
+
+        var sqs = entry.GetProperty("sqs");
+        Assert.Equal("msg-abc", sqs.GetProperty("messageId").GetString());
+        Assert.Equal("aws:sqs", sqs.GetProperty("eventSource").GetString());
+        Assert.Equal("arn:aws:sqs:us-east-1:1234:test-queue", sqs.GetProperty("eventSourceArn").GetString());
+        Assert.Equal("value-1", sqs.GetProperty("attributes").GetProperty("CustomAttr").GetString());
+        Assert.Equal("msg-abc", entry.GetProperty("correlationId").GetString());
+    }
+
+    [Fact]
+    public void AddApiGatewayContext_Captures_Http_Request_And_Sets_Correlation_Id()
+    {
+        var (logger, writer) = Build();
+        var request = new APIGatewayProxyRequest
+        {
+            HttpMethod = "POST",
+            Path = "/things/42",
+            Headers = new Dictionary<string, string>
+            {
+                ["Authorization"] = "Bearer leak-me",
+                ["User-Agent"] = "smoo/1.0",
+            },
+            QueryStringParameters = new Dictionary<string, string> { ["foo"] = "bar" },
+            RequestContext = new APIGatewayProxyRequest.ProxyRequestContext
+            {
+                RequestId = "apigw-req-1",
+                Stage = "prod",
+                ApiId = "api123",
+            },
+        };
+        logger.AddApiGatewayContext(request);
+        logger.LogInfo("apigw");
+        var entry = ParseSingle(writer.ToString());
+
+        var http = entry.GetProperty("http").GetProperty("request");
+        Assert.Equal("POST", http.GetProperty("method").GetString());
+        Assert.Equal("/things/42", http.GetProperty("path").GetString());
+        // SMOODEV-942 redaction is applied — Authorization should be redacted
+        Assert.Equal(SmooLogger.RedactedValue, http.GetProperty("headers").GetProperty("Authorization").GetString());
+        Assert.Equal("smoo/1.0", http.GetProperty("headers").GetProperty("User-Agent").GetString());
+
+        var apigw = entry.GetProperty("apiGateway");
+        Assert.Equal("apigw-req-1", apigw.GetProperty("requestId").GetString());
+        Assert.Equal("prod", apigw.GetProperty("stage").GetString());
+        Assert.Equal("api123", apigw.GetProperty("apiId").GetString());
+
+        Assert.Equal("apigw-req-1", entry.GetProperty("correlationId").GetString());
+    }
+
+    /// <summary>
+    /// Minimal ILambdaContext stub for unit tests. Amazon.Lambda.TestUtilities
+    /// would add a test-only dep — easier to roll our own.
+    /// </summary>
+    private sealed class TestLambdaContext : ILambdaContext
+    {
+        public string AwsRequestId { get; set; } = string.Empty;
+        public IClientContext ClientContext { get; set; } = null!;
+        public string FunctionName { get; set; } = string.Empty;
+        public string FunctionVersion { get; set; } = string.Empty;
+        public ICognitoIdentity Identity { get; set; } = null!;
+        public string InvokedFunctionArn { get; set; } = string.Empty;
+        public ILambdaLogger Logger { get; set; } = null!;
+        public string LogGroupName { get; set; } = string.Empty;
+        public string LogStreamName { get; set; } = string.Empty;
+        public int MemoryLimitInMB { get; set; }
+        public TimeSpan RemainingTime { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- New `SmooAI.Logger.AwsServerLogger : SmooLogger` mirrors the TS / Python / Go AwsServerLogger surfaces.
- Methods: `AddLambdaContext`, `AddLambdaEnvironmentContext`, `AddSqsRecordContext`, `AddApiGatewayContext`, `AddECSContext`.
- Adds NuGet refs `Amazon.Lambda.Core` 2.5.0, `Amazon.Lambda.SQSEvents` 2.2.0, `Amazon.Lambda.APIGatewayEvents` 2.7.1 — small, version-stable interface packages every .NET Lambda project pulls in anyway.

## Why
Previously `SmooAI.Logger` had no AWS surface at all. .NET Lambda services using SmooLogger had to manually populate invocation metadata into the context every handler, or skip it entirely. This brings the .NET port to parity with TS / Python / Go for AWS observability.

## File rotation
The ticket also called for file rotation parity. Deferring that to a follow-up — it's the smaller of the two gaps and implementing a full size-based rollover layer is non-trivial. AWS context unblocks the bigger observability gap.

## Test plan
- [x] All 5 new context helpers covered by xunit tests using realistic event payloads
- [x] Existing 24 SmooLoggerTests still pass — 29 total green
- [x] API Gateway test also confirms SMOODEV-942 redaction kicks in for Authorization headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)