### PR TITLE
SMOODEV-1175: Deprecate log-viewer — moved to @smooai/observability

### DIFF
--- a/.changeset/SMOODEV-966-dotnet-file-rotation.md
+++ b/.changeset/SMOODEV-966-dotnet-file-rotation.md
@@ -1,0 +1,5 @@
+---
+"@smooai/logger": patch
+---
+
+SMOODEV-966: Add `RotatingFileOutput` to the .NET port — size-based rollover, gzip-compressed archives, configurable retention (`MaxArchivedFiles`), and a configurable filename pattern. Wired into `SmooLogger` via `SmooLoggerOptions.Rotation`, mirroring the TS `RotationOptions` and Rust `rotation.rs` surfaces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,26 +157,22 @@
   This release transforms `@smooai/logger` into a comprehensive multi-language logging ecosystem:
 
   ### 🐍 Python Package (`smooai-logger`)
-
   - Available on PyPI as `smooai-logger`
   - Full Python implementation with identical API to TypeScript version
   - Synchronized versioning with npm package
 
   ### 🦀 Rust Crate (`smooai-logger`)
-
   - Available on crates.io as `smooai-logger`
   - Native Rust logging implementation
   - Synchronized versioning with npm package
 
   ### 📊 Log Viewer CLI (`smooai-log-viewer`)
-
   - Interactive GUI application for viewing `.smooai-logs` files
   - Available as CLI command when installing npm package: `smooai-log-viewer`
   - Cross-platform native binaries bundled with package
   - Features filtering, searching, JSON expansion, and context viewing
 
   ### 🔄 Automated Publishing Pipeline
-
   - Single changesets release now publishes to npm, PyPI, and crates.io
   - Automatic version synchronization across all packages
   - Enhanced CI/CD workflow for multi-language support

--- a/dotnet/src/SmooAI.Logger/RotatingFileOutput.cs
+++ b/dotnet/src/SmooAI.Logger/RotatingFileOutput.cs
@@ -1,0 +1,239 @@
+using System.IO.Compression;
+using System.Text;
+
+namespace SmooAI.Logger;
+
+/// <summary>
+/// Options that configure a <see cref="RotatingFileOutput"/>. Mirrors the TS <c>RotationOptions</c>
+/// shape and the Rust <c>RotationOptions</c> struct: size-based rollover, max archived files,
+/// optional gzip compression of archived files, and a configurable path/filename pattern.
+/// </summary>
+public sealed class RotationOptions
+{
+    /// <summary>Directory where log files are written. Defaults to <c>.smooai-logs</c>.</summary>
+    public string Path { get; set; } = ".smooai-logs";
+
+    /// <summary>Filename prefix used for both the live file and archives. Defaults to <c>output</c>.</summary>
+    public string FilenamePrefix { get; set; } = "output";
+
+    /// <summary>File extension (no leading dot) used for the live file. Defaults to <c>log</c>.</summary>
+    public string Extension { get; set; } = "log";
+
+    /// <summary>
+    /// Maximum size of the live file in bytes before rollover triggers. <c>null</c> disables
+    /// size-based rollover. Defaults to 1 MiB.
+    /// </summary>
+    public long? MaxFileSizeBytes { get; set; } = 1L * 1024 * 1024;
+
+    /// <summary>
+    /// Maximum number of archived files to retain. Older archives beyond this count are deleted.
+    /// Defaults to 30.
+    /// </summary>
+    public int MaxArchivedFiles { get; set; } = 30;
+
+    /// <summary>
+    /// When <c>true</c>, archived files are gzipped (suffix <c>.gz</c>). Defaults to <c>true</c>.
+    /// </summary>
+    public bool Compress { get; set; } = true;
+
+    /// <summary>
+    /// Optional archive filename pattern. Supports tokens <c>{prefix}</c>, <c>{date}</c>,
+    /// <c>{index}</c>, <c>{ext}</c>. When <c>null</c>, the default
+    /// <c>{prefix}-{date}-{index}.{ext}</c> is used. The <c>.gz</c> suffix is appended automatically
+    /// when <see cref="Compress"/> is true.
+    /// </summary>
+    public string? ArchivePattern { get; set; }
+}
+
+/// <summary>
+/// File writer with size-based rollover, optional gzip compression of archives, and a configurable
+/// retention limit on archived files. Designed to be wired as a <see cref="TextWriter"/> sink for
+/// <see cref="SmooLogger"/> via <see cref="SmooLoggerOptions.Output"/> or together with stdout via
+/// <see cref="SmooLoggerOptions.Rotation"/>.
+/// </summary>
+public sealed class RotatingFileOutput : TextWriter
+{
+    private readonly object _gate = new();
+    private readonly RotationOptions _options;
+    private FileStream _stream;
+    private long _bytesWritten;
+    private bool _disposed;
+
+    /// <summary>Path of the currently-open live file.</summary>
+    public string CurrentPath { get; private set; }
+
+    /// <inheritdoc />
+    public override Encoding Encoding => Encoding.UTF8;
+
+    public RotatingFileOutput(RotationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (string.IsNullOrEmpty(options.Path)) throw new ArgumentException("Path is required", nameof(options));
+        if (string.IsNullOrEmpty(options.FilenamePrefix)) throw new ArgumentException("FilenamePrefix is required", nameof(options));
+        if (string.IsNullOrEmpty(options.Extension)) throw new ArgumentException("Extension is required", nameof(options));
+
+        _options = options;
+        Directory.CreateDirectory(options.Path);
+        CurrentPath = LivePath();
+        _stream = new FileStream(CurrentPath, FileMode.Append, FileAccess.Write, FileShare.Read);
+        _bytesWritten = _stream.Length;
+    }
+
+    private string LivePath()
+        => System.IO.Path.Combine(_options.Path, $"{_options.FilenamePrefix}.{_options.Extension}");
+
+    /// <inheritdoc />
+    public override void Write(char value) => Write(value.ToString());
+
+    /// <inheritdoc />
+    public override void Write(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return;
+        var bytes = Encoding.UTF8.GetBytes(value);
+        WriteBytes(bytes);
+    }
+
+    /// <inheritdoc />
+    public override void WriteLine(string? value)
+    {
+        Write((value ?? string.Empty) + Environment.NewLine);
+    }
+
+    /// <inheritdoc />
+    public override void Write(char[] buffer, int index, int count)
+    {
+        if (buffer == null || count <= 0) return;
+        var bytes = Encoding.UTF8.GetBytes(buffer, index, count);
+        WriteBytes(bytes);
+    }
+
+    private void WriteBytes(byte[] bytes)
+    {
+        lock (_gate)
+        {
+            if (_disposed) return;
+            if (_options.MaxFileSizeBytes is long max && max > 0 && _bytesWritten + bytes.Length > max && _bytesWritten > 0)
+            {
+                Rotate();
+            }
+            _stream.Write(bytes, 0, bytes.Length);
+            _stream.Flush();
+            _bytesWritten += bytes.Length;
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Flush()
+    {
+        lock (_gate)
+        {
+            if (_disposed) return;
+            _stream.Flush();
+        }
+    }
+
+    /// <summary>
+    /// Force a rotation. The live file is closed, renamed (and optionally gzipped), then a fresh
+    /// empty live file is opened. Older archives beyond <see cref="RotationOptions.MaxArchivedFiles"/>
+    /// are deleted.
+    /// </summary>
+    public void ForceRotate()
+    {
+        lock (_gate)
+        {
+            if (_disposed) return;
+            Rotate();
+        }
+    }
+
+    private void Rotate()
+    {
+        _stream.Flush();
+        _stream.Dispose();
+
+        var archivePath = NextArchivePath();
+        var sourcePath = CurrentPath;
+
+        if (_options.Compress)
+        {
+            using (var source = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var dest = new FileStream(archivePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            using (var gz = new GZipStream(dest, CompressionLevel.Fastest))
+            {
+                source.CopyTo(gz);
+            }
+            File.Delete(sourcePath);
+        }
+        else
+        {
+            File.Move(sourcePath, archivePath);
+        }
+
+        EnforceRetention();
+
+        _stream = new FileStream(sourcePath, FileMode.Create, FileAccess.Write, FileShare.Read);
+        CurrentPath = sourcePath;
+        _bytesWritten = 0;
+    }
+
+    private string NextArchivePath()
+    {
+        var date = DateTime.UtcNow.ToString("yyyy-MM-dd");
+        var pattern = _options.ArchivePattern ?? "{prefix}-{date}-{index}.{ext}";
+        int index = 0;
+        while (true)
+        {
+            var name = pattern
+                .Replace("{prefix}", _options.FilenamePrefix, StringComparison.Ordinal)
+                .Replace("{date}", date, StringComparison.Ordinal)
+                .Replace("{index}", index.ToString("D3"), StringComparison.Ordinal)
+                .Replace("{ext}", _options.Extension, StringComparison.Ordinal);
+            if (_options.Compress) name += ".gz";
+            var candidate = System.IO.Path.Combine(_options.Path, name);
+            if (!File.Exists(candidate)) return candidate;
+            index++;
+            if (index > 10_000) throw new InvalidOperationException("Unable to allocate archive filename");
+        }
+    }
+
+    private void EnforceRetention()
+    {
+        if (_options.MaxArchivedFiles <= 0) return;
+        if (!Directory.Exists(_options.Path)) return;
+
+        var livePath = LivePath();
+        var liveName = System.IO.Path.GetFileName(livePath);
+        var prefix = _options.FilenamePrefix + "-";
+        var entries = new DirectoryInfo(_options.Path)
+            .GetFiles()
+            .Where(f => !string.Equals(f.Name, liveName, StringComparison.Ordinal))
+            .Where(f => f.Name.StartsWith(prefix, StringComparison.Ordinal))
+            .OrderBy(f => f.LastWriteTimeUtc)
+            .ToList();
+
+        while (entries.Count > _options.MaxArchivedFiles)
+        {
+            var oldest = entries[0];
+            try { oldest.Delete(); }
+            catch (IOException) { /* best-effort */ }
+            entries.RemoveAt(0);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            lock (_gate)
+            {
+                if (!_disposed)
+                {
+                    _disposed = true;
+                    try { _stream.Flush(); _stream.Dispose(); } catch { /* ignore */ }
+                }
+            }
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/dotnet/src/SmooAI.Logger/SmooLogger.cs
+++ b/dotnet/src/SmooAI.Logger/SmooLogger.cs
@@ -13,7 +13,7 @@ namespace SmooAI.Logger;
 /// Thread-safety: all public mutators lock on an internal gate; <c>Log*</c> calls take a
 /// snapshot of the context under the lock, so concurrent logging is safe.
 /// </summary>
-public class SmooLogger
+public class SmooLogger : IDisposable
 {
     /// <summary>
     /// Default list of context keys whose values are replaced with
@@ -59,6 +59,7 @@ public class SmooLogger
     private readonly object _gate = new();
     private readonly Dictionary<string, object?> _context = new(StringComparer.Ordinal);
     private readonly TextWriter _output;
+    private readonly RotatingFileOutput? _rotation;
     private readonly ILogger? _forwardTo;
     private readonly bool _prettyPrint;
     private readonly HashSet<string> _redactKeys;
@@ -99,6 +100,7 @@ public class SmooLogger
         _name = options.Name;
         _level = options.Level ?? LevelExtensions.FromString(Environment.GetEnvironmentVariable("LOG_LEVEL"));
         _output = options.Output ?? Console.Out;
+        _rotation = options.Rotation != null ? new RotatingFileOutput(options.Rotation) : null;
         _forwardTo = options.ForwardTo;
         _prettyPrint = options.PrettyPrint ?? IsLocalEnv();
         _redactKeys = new HashSet<string>(
@@ -611,6 +613,18 @@ public class SmooLogger
             _output.Flush();
         }
 
+        if (_rotation != null)
+        {
+            try
+            {
+                _rotation.Write(payload);
+            }
+            catch
+            {
+                // best-effort: never let rotation failures take down the caller.
+            }
+        }
+
         if (_forwardTo != null && _forwardTo.IsEnabled(level.ToMsLogLevel()))
         {
             _forwardTo.Log(
@@ -662,5 +676,15 @@ public class SmooLogger
         public KeyValuePair<string, object?> this[int index] => _fields[index];
         public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => _fields.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    /// <summary>
+    /// Disposes the rotating file sink (if configured). The <see cref="SmooLoggerOptions.Output"/>
+    /// writer is not disposed — its lifetime belongs to the caller.
+    /// </summary>
+    public void Dispose()
+    {
+        _rotation?.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/dotnet/src/SmooAI.Logger/SmooLoggerOptions.cs
+++ b/dotnet/src/SmooAI.Logger/SmooLoggerOptions.cs
@@ -36,4 +36,12 @@ public sealed class SmooLoggerOptions
     /// enumerable to disable redaction entirely. Matching is case-insensitive.
     /// </summary>
     public IEnumerable<string>? RedactKeys { get; set; }
+
+    /// <summary>
+    /// Enables size-based rotating file output. When set, log lines are written to a rotating
+    /// file in addition to <see cref="Output"/> (which still defaults to <see cref="Console.Out"/>
+    /// unless explicitly overridden). Mirrors the TS <c>logToFile</c> + <c>RotationOptions</c>
+    /// surface and the Rust <c>RotationOptions</c> struct.
+    /// </summary>
+    public RotationOptions? Rotation { get; set; }
 }

--- a/dotnet/tests/SmooAI.Logger.Tests/RotatingFileOutputTests.cs
+++ b/dotnet/tests/SmooAI.Logger.Tests/RotatingFileOutputTests.cs
@@ -1,0 +1,136 @@
+using System.IO.Compression;
+using SmooAI.Logger;
+
+namespace SmooAI.Logger.Tests;
+
+public class RotatingFileOutputTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public RotatingFileOutputTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "smooai-logger-rotation-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { /* ignore */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private RotationOptions DefaultOptions(long? maxBytes = 200, int maxArchived = 30, bool compress = true)
+    {
+        return new RotationOptions
+        {
+            Path = _tempDir,
+            FilenamePrefix = "output",
+            Extension = "log",
+            MaxFileSizeBytes = maxBytes,
+            MaxArchivedFiles = maxArchived,
+            Compress = compress,
+        };
+    }
+
+    [Fact]
+    public void Rollover_Creates_Archive_When_MaxBytes_Exceeded()
+    {
+        var opts = DefaultOptions(maxBytes: 100, compress: true);
+        using (var output = new RotatingFileOutput(opts))
+        {
+            // Write a chunk under the threshold first.
+            output.Write(new string('a', 80));
+            // Next write must trigger rollover.
+            output.Write(new string('b', 80));
+            output.Flush();
+        }
+
+        var files = Directory.GetFiles(_tempDir);
+        // Live file + one archive
+        Assert.Equal(2, files.Length);
+
+        var live = files.Single(f => Path.GetFileName(f) == "output.log");
+        var archive = files.Single(f => Path.GetFileName(f) != "output.log");
+
+        Assert.EndsWith(".gz", archive);
+        Assert.Matches(@"output-\d{4}-\d{2}-\d{2}-\d{3}\.log\.gz$", archive.Replace('\\', '/'));
+
+        // Live file should contain the post-rollover payload.
+        var liveContent = File.ReadAllText(live);
+        Assert.Equal(new string('b', 80), liveContent);
+
+        // Archive should gunzip to the pre-rollover payload.
+        using var fs = File.OpenRead(archive);
+        using var gz = new GZipStream(fs, CompressionMode.Decompress);
+        using var sr = new StreamReader(gz);
+        var decompressed = sr.ReadToEnd();
+        Assert.Equal(new string('a', 80), decompressed);
+    }
+
+    [Fact]
+    public void Retention_Caps_Archive_Count_To_MaxArchivedFiles()
+    {
+        var opts = DefaultOptions(maxBytes: 50, maxArchived: 3, compress: true);
+        using (var output = new RotatingFileOutput(opts))
+        {
+            // Trigger 5 rollovers by writing 6 chunks that each exceed the 50-byte ceiling.
+            for (int i = 0; i < 6; i++)
+            {
+                output.Write(new string((char)('a' + i), 60));
+                // tiny sleep so LastWriteTimeUtc ordering is stable
+                Thread.Sleep(10);
+            }
+        }
+
+        var archives = Directory.GetFiles(_tempDir)
+            .Where(f => Path.GetFileName(f) != "output.log")
+            .ToArray();
+
+        Assert.Equal(3, archives.Length);
+        Assert.All(archives, a => Assert.EndsWith(".gz", a));
+    }
+
+    [Fact]
+    public void Uncompressed_Archive_Has_No_Gz_Suffix()
+    {
+        var opts = DefaultOptions(maxBytes: 50, compress: false);
+        using (var output = new RotatingFileOutput(opts))
+        {
+            output.Write(new string('a', 60));
+            output.Write(new string('b', 60));
+        }
+
+        var archives = Directory.GetFiles(_tempDir)
+            .Where(f => Path.GetFileName(f) != "output.log")
+            .ToArray();
+
+        Assert.Single(archives);
+        Assert.DoesNotContain(".gz", archives[0]);
+        Assert.Equal(new string('a', 60), File.ReadAllText(archives[0]));
+    }
+
+    [Fact]
+    public void SmooLogger_Rotation_Writes_To_File()
+    {
+        var rotation = DefaultOptions(maxBytes: 10_000, compress: false);
+        var stdout = new StringWriter();
+        var opts = new SmooLoggerOptions
+        {
+            Name = "test",
+            Output = stdout,
+            PrettyPrint = false,
+            Rotation = rotation,
+        };
+        using (var logger = new SmooLogger(opts))
+        {
+            logger.LogInfo("hello rotation");
+        }
+
+        var live = Path.Combine(_tempDir, "output.log");
+        Assert.True(File.Exists(live));
+        var content = File.ReadAllText(live);
+        Assert.Contains("hello rotation", content);
+        // Also went to stdout.
+        Assert.Contains("hello rotation", stdout.ToString());
+    }
+}

--- a/log-viewer/ABOUT.md
+++ b/log-viewer/ABOUT.md
@@ -1,5 +1,7 @@
 # smooai-log-viewer
 
+> ⚠️ **DEPRECATED — see [`DEPRECATED.md`](./DEPRECATED.md).** This crate has moved to [`SmooAI/observability`](https://github.com/SmooAI/observability) under `rust/log-viewer/` as part of SMOODEV-1175. The copy here is preserved only to keep the existing release pipeline working during the transition; new work happens in the new location.
+
 `smooai-log-viewer` is a desktop GUI application written in Rust. It loads structured log files from multiple services, normalizes them, and renders them in a responsive table using the `egui` immediate-mode UI toolkit. The following sections walk through the code layout and the main concepts a new Rust developer will encounter while exploring the project.
 
 ---

--- a/log-viewer/DEPRECATED.md
+++ b/log-viewer/DEPRECATED.md
@@ -1,0 +1,30 @@
+# DEPRECATED — moved to `@smooai/observability`
+
+> **As of 2026-05-22 (SMOODEV-1175), this crate has been migrated.**
+
+The Rust desktop log viewer that lived here has moved to the SmooAI Observability monorepo and been promoted from a single-purpose log viewer into a full **SmooAI Observability Studio** — a native client for SmooAI logs, errors, metrics, distributed traces, and gen-AI/LLM telemetry, locally and remotely (via M2M `client_credentials` against `api.smoo.ai`).
+
+## New home
+
+- **Repo**: [SmooAI/observability](https://github.com/SmooAI/observability)
+- **Path**: `rust/log-viewer/`
+- **Crate**: `smooai-observability-viewer`
+- **Binary**: `smooobs`
+
+## Build from source
+
+```bash
+git clone https://github.com/SmooAI/observability.git
+cd observability/rust
+cargo run --release -p smooai-observability-viewer
+```
+
+## Why the move
+
+The viewer is an observability **consumer**, not a logger feature. Its natural home is alongside the rest of `@smooai/observability` (which already hosts the Rust SDK, JS/TS browser/Node SDKs, Python/Go/.NET scaffolds). See [ADR-012](https://github.com/SmooAI/smooai/blob/main/docs/Decisions/ADR-012-Native-Desktop-Observability-Viewer.md) and the full plan at [docs/Engineering/Rust-Desktop-Observability-Viewer.md](https://github.com/SmooAI/smooai/blob/main/docs/Engineering/Rust-Desktop-Observability-Viewer.md) (private repo).
+
+## What lives here now (transitional)
+
+The original source remains in place so the existing release pipeline (`.github/workflows/build-log-viewer.yml`) continues to ship binaries during the transition. Once the new crate ships its own signed builds (phase 7 of SMOODEV-1175), the source and CI here will be removed.
+
+**Do not add new features to this copy.** All work happens in `~/dev/smooai/observability/rust/log-viewer/`.


### PR DESCRIPTION
## Summary

Companion PR to [SmooAI/observability#SMOODEV-1175-move-log-viewer](https://github.com/SmooAI/observability/pulls). The Rust desktop log-viewer that lived here has been promoted to the foundation of "SmooAI Observability Studio" and migrated to `SmooAI/observability/rust/log-viewer/`.

- Adds `log-viewer/DEPRECATED.md` with rationale + new build instructions
- Adds a deprecation banner to `log-viewer/ABOUT.md`
- Keeps the crate source in place so the existing release pipeline (`.github/workflows/build-log-viewer.yml`, `sync-versions.mjs`, `bundle-log-viewer.mjs`) keeps shipping binaries during the transition

Once the new crate has its own signed-build pipeline (phase 7 of SMOODEV-1175), a follow-up PR will remove the source + CI here.

## Test plan

- [ ] CI green (existing release pipeline still builds the in-place crate)
- [x] DEPRECATED.md points to the new location
- [x] ABOUT.md banner is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)