### PR TITLE
SMOODEV-1255: Update deprecation pointer to studio-v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,26 +175,22 @@
   This release transforms `@smooai/logger` into a comprehensive multi-language logging ecosystem:
 
   ### 🐍 Python Package (`smooai-logger`)
-
   - Available on PyPI as `smooai-logger`
   - Full Python implementation with identical API to TypeScript version
   - Synchronized versioning with npm package
 
   ### 🦀 Rust Crate (`smooai-logger`)
-
   - Available on crates.io as `smooai-logger`
   - Native Rust logging implementation
   - Synchronized versioning with npm package
 
   ### 📊 Log Viewer CLI (`smooai-log-viewer`)
-
   - Interactive GUI application for viewing `.smooai-logs` files
   - Available as CLI command when installing npm package: `smooai-log-viewer`
   - Cross-platform native binaries bundled with package
   - Features filtering, searching, JSON expansion, and context viewing
 
   ### 🔄 Automated Publishing Pipeline
-
   - Single changesets release now publishes to npm, PyPI, and crates.io
   - Automatic version synchronization across all packages
   - Enhanced CI/CD workflow for multi-language support

--- a/log-viewer/DEPRECATED.md
+++ b/log-viewer/DEPRECATED.md
@@ -1,30 +1,41 @@
 # DEPRECATED — moved to `@smooai/observability`
 
 > **As of 2026-05-22 (SMOODEV-1175), this crate has been migrated.**
+> **As of `studio-v0.1.0` (SMOODEV-1255), the egui implementation is gone.** The replacement is a Dioxus app, distributed via GitHub Releases.
 
-The Rust desktop log viewer that lived here has moved to the SmooAI Observability monorepo and been promoted from a single-purpose log viewer into a full **SmooAI Observability Studio** — a native client for SmooAI logs, errors, metrics, distributed traces, and gen-AI/LLM telemetry, locally and remotely (via M2M `client_credentials` against `api.smoo.ai`).
+The Rust desktop log viewer that lived here has moved to the SmooAI Observability monorepo and been rebuilt from scratch as **SmooAI Observability Studio** — a Dioxus 0.6 native client for SmooAI logs, errors, metrics (traces + gen-AI coming), reached over M2M `client_credentials` against `api.smoo.ai`.
 
-## New home
+## Get the app
 
-- **Repo**: [SmooAI/observability](https://github.com/SmooAI/observability)
-- **Path**: `rust/log-viewer/`
-- **Crate**: `smooai-observability-viewer`
-- **Binary**: `smooobs`
+**Download a release** (signed builds coming in a follow-up):
 
-## Build from source
+- macOS (arm64): [`SmooAI-Observability-Studio.dmg`](https://github.com/SmooAI/observability/releases/tag/studio-v0.1.0)
+- Linux x86_64: [`SmooAI-Observability-Studio-x86_64.AppImage`](https://github.com/SmooAI/observability/releases/tag/studio-v0.1.0)
+- Windows x86_64: [`SmooAI-Observability-Studio-x86_64.zip`](https://github.com/SmooAI/observability/releases/tag/studio-v0.1.0)
+
+Full release list: <https://github.com/SmooAI/observability/releases>.
+
+**Or build from source**:
 
 ```bash
 git clone https://github.com/SmooAI/observability.git
-cd observability/rust
-cargo run --release -p smooai-observability-viewer
+cd observability/desktop
+cargo run --release -p observability-studio-app
 ```
+
+The new layout:
+
+- **Repo**: [SmooAI/observability](https://github.com/SmooAI/observability)
+- **Path**: `desktop/`
+- **Workspace crates**: `observability-studio-app` (binary `observability-studio`), `observability-studio-client`, `observability-studio-theme`
+- **Design system**: shared via [`@smooai/ui`](https://github.com/SmooAI/ui) (the `smooai-ui` crate)
 
 ## Why the move
 
-The viewer is an observability **consumer**, not a logger feature. Its natural home is alongside the rest of `@smooai/observability` (which already hosts the Rust SDK, JS/TS browser/Node SDKs, Python/Go/.NET scaffolds). See [ADR-013](https://github.com/SmooAI/smooai/blob/main/docs/Decisions/ADR-013-Native-Desktop-Observability-Viewer.md) and the full plan at [docs/Engineering/Rust-Desktop-Observability-Viewer.md](https://github.com/SmooAI/smooai/blob/main/docs/Engineering/Rust-Desktop-Observability-Viewer.md) (private repo).
+The viewer is an observability **consumer**, not a logger feature. Its natural home is alongside the rest of `@smooai/observability` (which already hosts the Rust SDK, JS/TS browser/Node SDKs, Python/Go/.NET scaffolds). See [ADR-013](https://github.com/SmooAI/smooai/blob/main/docs/Decisions/ADR-013-Native-Desktop-Observability-Viewer.md) (private smooai repo).
 
-## What lives here now (transitional)
+## Notes on the previous egui implementation
 
-The original source remains in place so the existing release pipeline (`.github/workflows/build-log-viewer.yml`) continues to ship binaries during the transition. Once the new crate ships its own signed builds (phase 7 of SMOODEV-1175), the source and CI here will be removed.
+The original `smooai-log-viewer` egui crate was deleted in [observability `SMOODEV-1255-rm-egui`](https://github.com/SmooAI/observability/pull/) once the Dioxus port reached parity (logs / errors / metrics views — local-file ingestion was the only feature not ported, and that workflow is better served by running the AWS / CloudWatch source through the new Settings → Add Org flow against `api.smoo.ai`).
 
-**Do not add new features to this copy.** All work happens in `~/dev/smooai/observability/rust/log-viewer/`.
+If you depended on the old egui binary specifically, pin to a [SmooAI/logger v4.x release](https://github.com/SmooAI/logger/releases) that predates this deprecation note — but expect no further updates on that line.


### PR DESCRIPTION
## Summary
- Point `log-viewer/DEPRECATED.md` at the published Observability Studio release (studio-v0.1.0)
- Trim some blank-line-after-heading noise in CHANGELOG.md (prettier-driven)

The Dioxus port now has parity + macOS/Linux/Windows installers, so anyone landing on the deprecated log-viewer should download from the studio release instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)