### PR TITLE
Enable smooth-agent@smooth Claude Code plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,36 +1,47 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
-          }
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Edit|Write",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
+                    }
+                ]
+            },
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
+                    }
+                ]
+            }
+        ],
+        "SessionStart": [
+            {
+                "matcher": "startup",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "BRANCH=$(git -C \"$CLAUDE_PROJECT_DIR\" symbolic-ref --short HEAD 2>/dev/null); if [[ \"$BRANCH\" == \"main\" || \"$BRANCH\" == \"master\" ]]; then REPO_NAME=$(basename \"$CLAUDE_PROJECT_DIR\"); echo \"\u26a0\ufe0f  You are in the MAIN worktree on the main branch. Do NOT do feature work here. Create a worktree first: git worktree add ../${REPO_NAME}-SMOODEV-XX-desc -b SMOODEV-XX-desc main\"; fi"
+                    }
+                ]
+            }
         ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-worktree.sh"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "startup",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "BRANCH=$(git -C \"$CLAUDE_PROJECT_DIR\" symbolic-ref --short HEAD 2>/dev/null); if [[ \"$BRANCH\" == \"main\" || \"$BRANCH\" == \"master\" ]]; then REPO_NAME=$(basename \"$CLAUDE_PROJECT_DIR\"); echo \"⚠️  You are in the MAIN worktree on the main branch. Do NOT do feature work here. Create a worktree first: git worktree add ../${REPO_NAME}-SMOODEV-XX-desc -b SMOODEV-XX-desc main\"; fi"
-          }
-        ]
-      }
-    ]
-  }
+    },
+    "extraKnownMarketplaces": {
+        "smooth": {
+            "source": {
+                "source": "github",
+                "repo": "SmooAI/smooth"
+            }
+        }
+    },
+    "enabledPlugins": {
+        "smooth-agent@smooth": true
+    }
 }


### PR DESCRIPTION
Adds the SmooAI `smooth` plugin marketplace and enables `smooth-agent@smooth` so every Claude Code session in this repo joins the th-mail agent bus (active + mailable), gets `/smooth` + the agent-comms/pearls-flow skills, and picks up the shared SmooAI repo guardrail hooks. Additive, dev-tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)