### PR TITLE
Correlate .NET logger trace id with active span (th-de3805)

### DIFF
--- a/.changeset/dotnet-otel-correlation.md
+++ b/.changeset/dotnet-otel-correlation.md
@@ -1,0 +1,13 @@
+---
+'@smooai/logger': patch
+---
+
+.NET: log records now carry the active OTel span's real W3C `traceId`/`spanId`
+via `Activity.Current`, falling back to the correlation uuid when no valid
+activity is in scope.
+
+The version bump for the .NET package is driven from `package.json` by
+`scripts/sync-versions.mjs`, so this file exists to make sure the release
+CHANGELOG actually mentions the change — without it the NuGet package still
+republishes (any changeset in the release triggers every language), just with no
+record of what changed.

--- a/dotnet/src/SmooAI.Logger/LogContext.cs
+++ b/dotnet/src/SmooAI.Logger/LogContext.cs
@@ -23,6 +23,7 @@ public static class ContextKey
     public const string RequestId = "requestId";
     public const string Duration = "duration";
     public const string TraceId = "traceId";
+    public const string SpanId = "spanId";
     public const string Error = "error";
     public const string Namespace = "namespace";
     public const string Service = "service";

--- a/dotnet/src/SmooAI.Logger/SmooLogger.cs
+++ b/dotnet/src/SmooAI.Logger/SmooLogger.cs
@@ -428,6 +428,18 @@ public class SmooLogger : IDisposable
             }
         }
 
+        // Correlate with the active distributed trace when one is in scope: stamp the
+        // real W3C trace/span id from Activity.Current instead of the fabricated uuid
+        // seeded at construction. Falls back to the prior traceId (no spanId) when no
+        // W3C activity is active. This is captured at emit time — the span is live at
+        // the log call, not necessarily when the logger was created.
+        var activity = System.Diagnostics.Activity.Current;
+        if (activity is not null && activity.IdFormat == System.Diagnostics.ActivityIdFormat.W3C)
+        {
+            entry[ContextKey.TraceId] = activity.TraceId.ToHexString();
+            entry[ContextKey.SpanId] = activity.SpanId.ToHexString();
+        }
+
         entry[ContextKey.Level] = (int)level;
         entry[ContextKey.LogLevel] = level.ToWireString();
         entry[ContextKey.Time] = DateTimeOffset.UtcNow.ToString("O");

--- a/dotnet/tests/SmooAI.Logger.Tests/TraceCorrelationTests.cs
+++ b/dotnet/tests/SmooAI.Logger.Tests/TraceCorrelationTests.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics;
+using System.Text.Json;
+using SmooAI.Logger;
+
+namespace SmooAI.Logger.Tests;
+
+/// <summary>
+/// Verifies the emit-time trace correlation (th-de3805): a log emitted inside an
+/// active W3C <see cref="Activity"/> carries that span's real trace/span id, and
+/// falls back to the fabricated correlation uuid when no activity is in scope.
+/// </summary>
+public class TraceCorrelationTests
+{
+    private static (SmooLogger Logger, StringWriter Out) Build()
+    {
+        var writer = new StringWriter();
+        return (new SmooLogger(new SmooLoggerOptions { Output = writer, PrettyPrint = false }), writer);
+    }
+
+    private static JsonElement ParseSingle(string captured)
+    {
+        var line = captured.Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        return JsonDocument.Parse(line).RootElement;
+    }
+
+    [Fact]
+    public void Log_Within_Active_Activity_Carries_Real_TraceAndSpanId()
+    {
+        // ActivitySource only starts activities when a listener samples them.
+        using var source = new ActivitySource("smooai.logger.tests");
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == "smooai.logger.tests",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var (logger, writer) = Build();
+        using var activity = source.StartActivity("op");
+        Assert.NotNull(activity);
+        Assert.Equal(ActivityIdFormat.W3C, activity!.IdFormat);
+
+        logger.LogInfo("inside span");
+        var entry = ParseSingle(writer.ToString());
+
+        Assert.Equal(activity.TraceId.ToHexString(), entry.GetProperty("traceId").GetString());
+        Assert.Equal(activity.SpanId.ToHexString(), entry.GetProperty("spanId").GetString());
+    }
+
+    [Fact]
+    public void Log_Without_Activity_Falls_Back_To_Correlation_Uuid()
+    {
+        // No listener registered here, and any ambient activity cleared.
+        Activity.Current = null;
+
+        var (logger, writer) = Build();
+        logger.LogInfo("no span");
+        var entry = ParseSingle(writer.ToString());
+
+        // Prior behavior: traceId == the fabricated correlation id, no spanId emitted.
+        Assert.Equal(entry.GetProperty("correlationId").GetString(), entry.GetProperty("traceId").GetString());
+        Assert.False(entry.TryGetProperty("spanId", out _));
+    }
+}


### PR DESCRIPTION
## Problem
The .NET logger seeded `traceId` with a **fabricated uuid** (equal to `correlationId`) at construction. When a log is emitted inside an active distributed trace, the JSON logs (CloudWatch) did not carry the real trace id, so they couldn't be correlated to the trace.

## Solution
At emit time, when an active W3C `System.Diagnostics.Activity` is in scope, stamp the entry's `traceId` (and a new `spanId`) with the span's real W3C ids. Captured at **emit time**, not construction — the span is live at the log call, not necessarily when the logger was created. Falls back to the prior behavior (fabricated uuid `traceId`, no `spanId`) when no W3C activity is active.

- `SmooLogger.Emit`: override `traceId` + add `spanId` from `Activity.Current` (W3C format only).
- New `ContextKey.SpanId` (`"spanId"`).
- Depends only on the BCL diagnostics API (`Activity`) — **not** on `@smooai/observability` (that would be circular). Logger lines already flow through the `ForwardTo` `ILogger` the obs provider hooks, so when the observability OTel logging provider is active a logger line becomes an OTLP log record carrying the same ids.

## Verification
`Log_Within_Active_Activity_Carries_Real_TraceAndSpanId` starts a real `ActivitySource` span, logs, parses the JSON output, and asserts `traceId`/`spanId` equal `activity.TraceId`/`SpanId` hex. `Log_Without_Activity_Falls_Back_To_Correlation_Uuid` asserts the fallback (traceId == correlationId, no spanId).

`dotnet build` (net8/9/10, warnings-as-errors), `dotnet test` (35 passed, 2 new), and `dotnet format --verify-no-changes` all green in Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2bM94GAnVjYSSv1x7HKRB