### PR TITLE
Fix the Go module path to /v4 so tagged releases resolve

### DIFF
--- a/.changeset/go-module-v4.md
+++ b/.changeset/go-module-v4.md
@@ -1,0 +1,17 @@
+---
+"@smooai/logger": patch
+---
+
+Fix the Go module path so the Go port is installable again.
+
+`go/go.mod` declared `module github.com/SmooAI/logger/go/v3`, but every Go tag this repo has
+ever pushed is `go/v4.x` (`go/v4.1.3` … `go/v4.3.0`) — no `go/v3.*` tag has ever existed. Go
+resolves a `go/vN.x` tag only for a module path ending in `/vN`, so
+`go get github.com/SmooAI/logger/go/v3@v4.3.0` resolved nothing and the only thing that worked
+was a `main` pseudo-version. The Go port has been un-`go get`-able at a real version since v4.0.0.
+
+The module path is now `github.com/SmooAI/logger/go/v4`, matching the tags. A new
+`check:go-module` guard asserts the `/vN` suffix equals `package.json`'s major and **fails** on
+mismatch; it runs in PR checks and again inside the release tagging step, after changesets has
+bumped the version — the only point where the version that becomes the tag can be compared to
+the module path.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,6 +63,9 @@ jobs:
         run: uv sync --group dev
         working-directory: python
 
+      - name: Guard — Go module major matches package.json
+        run: pnpm check:go-module
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Guard — Go module major matches package.json
+        run: pnpm check:go-module
+
       - name: Typecheck
         run: pnpm typecheck
 
@@ -120,6 +123,10 @@ jobs:
       - name: Tag and publish Go module
         if: steps.changesets.outputs.published == 'true'
         run: |
+          # Guard here, not in the pre-flight checks: changesets has already
+          # bumped package.json by this point, so this is the only place the
+          # version that becomes the tag can be compared to the module path.
+          node scripts/check-go-module.mjs
           VERSION=$(node -p "require('./package.json').version")
           TAG="go/v${VERSION}"
           echo "Creating Go module tag: ${TAG}"

--- a/README.md
+++ b/README.md
@@ -206,10 +206,8 @@ logger.info('Checkout completed', { orderId: data.id });
 | **TypeScript** | [`@smooai/logger`](https://www.npmjs.com/package/@smooai/logger) | `pnpm add @smooai/logger` |
 | **Python** | [`smooai-logger`](https://pypi.org/project/smooai-logger/) | `pip install smooai-logger` (or `uv add smooai-logger`) |
 | **Rust** | [`smooai-logger`](https://crates.io/crates/smooai-logger) | `cargo add smooai-logger` |
-| **Go** | [`github.com/SmooAI/logger/go/v3`](https://pkg.go.dev/github.com/SmooAI/logger/go/v3) | `go get github.com/SmooAI/logger/go/v3` |
+| **Go** | [`github.com/SmooAI/logger/go/v4`](https://pkg.go.dev/github.com/SmooAI/logger/go/v4) | `go get github.com/SmooAI/logger/go/v4` |
 | **.NET** | [`SmooAI.Logger`](https://www.nuget.org/packages/SmooAI.Logger) | `dotnet add package SmooAI.Logger` |
-
-> **Go note:** the module path is `…/go/v3`, so `go get` resolves a pseudo-version tracking `main` rather than a tagged release — the repo's `go/v4.x` release tags don't match the `/v3` module path and are not resolvable. A tag-scheme fix is tracked separately; the pseudo-version install above works today.
 
 ## 🚀 Quickstart
 

--- a/go/README.md
+++ b/go/README.md
@@ -43,7 +43,7 @@ Check out other SmooAI packages at [smoo.ai/open-source](https://smoo.ai/open-so
 
 **The missing piece for AWS & Go logging** - A contextual logging system that automatically captures the full execution context you need to debug production issues, without the manual setup.
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/SmooAI/logger/go/v3.svg)](https://pkg.go.dev/github.com/SmooAI/logger/go/v3)
+[![Go Reference](https://pkg.go.dev/badge/github.com/SmooAI/logger/go/v4.svg)](https://pkg.go.dev/github.com/SmooAI/logger/go/v4)
 
 ![GitHub License](https://img.shields.io/github/license/SmooAI/logger?style=for-the-badge)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/SmooAI/logger/release.yml?style=for-the-badge)
@@ -71,7 +71,7 @@ Ever spent hours debugging a Go service in production, only to realize you're mi
 ### Install
 
 ```bash
-go get github.com/SmooAI/logger/go/v3
+go get github.com/SmooAI/logger/go/v4
 ```
 
 ### Cross-Language Support
@@ -83,7 +83,7 @@ The same structured log format works across all your services:
 | TypeScript | [`@smooai/logger`](https://www.npmjs.com/package/@smooai/logger) | `pnpm add @smooai/logger`               |
 | Python     | [`smooai-logger`](https://pypi.org/project/smooai-logger/)       | `pip install smooai-logger`             |
 | Rust       | [`smooai-logger`](https://crates.io/crates/smooai-logger)        | `cargo add smooai-logger`               |
-| Go         | `github.com/SmooAI/logger/go/v3`                                 | `go get github.com/SmooAI/logger/go/v3` |
+| Go         | `github.com/SmooAI/logger/go/v4`                                 | `go get github.com/SmooAI/logger/go/v4` |
 
 ## The Power of Automatic Context
 
@@ -92,7 +92,7 @@ The same structured log format works across all your services:
 Every log entry includes the exact location in your code:
 
 ```go
-import logger "github.com/SmooAI/logger/go/v3"
+import logger "github.com/SmooAI/logger/go/v4"
 
 log := logger.Default()
 log.Info("User created")
@@ -138,7 +138,7 @@ import (
 
     "github.com/aws/aws-lambda-go/events"
     "github.com/aws/aws-lambda-go/lambda"
-    logger "github.com/SmooAI/logger/go/v3"
+    logger "github.com/SmooAI/logger/go/v4"
 )
 
 var log *logger.LambdaLogger
@@ -175,7 +175,7 @@ func main() {
 ```go
 import (
     "os"
-    logger "github.com/SmooAI/logger/go/v3"
+    logger "github.com/SmooAI/logger/go/v4"
 )
 
 log, _ := logger.New(logger.Options{
@@ -331,7 +331,7 @@ log, _ := logger.New(logger.Options{
 ### Logger Creation
 
 ```go
-import logger "github.com/SmooAI/logger/go/v3"
+import logger "github.com/SmooAI/logger/go/v4"
 
 // With options
 prettyOn := true

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/SmooAI/logger/go/v3
+module github.com/SmooAI/logger/go/v4
 
 go 1.25.0
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "aibranch": "pnpm generate-git-branch",
     "build": "pnpm tsdown && cp src/decycle.cjs dist/ && pnpm run python:build && pnpm run rust:build && pnpm run go:build",
     "check-all": "pnpm run typecheck && pnpm run lint && pnpm run test && pnpm run rust:fmt:check && pnpm run rust:lint && pnpm run rust:test && pnpm run go:fmt:check && pnpm run go:lint && pnpm run go:test && pnpm run build",
+    "check:go-module": "node scripts/check-go-module.mjs",
     "ci:publish": "node scripts/ci-publish.mjs",
     "format": "oxfmt --write . && pnpm run python:format && pnpm run rust:fmt && pnpm run go:fmt",
     "go:build": "(cd go && go build ./...)",

--- a/scripts/check-go-module.mjs
+++ b/scripts/check-go-module.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * Guard: the `/vN` major suffix on the Go module path must match the major of
+ * `package.json`'s version, because release.yml mints the Go tag as
+ * `go/v${package.json version}`.
+ *
+ * This is the check whose absence let `module github.com/SmooAI/logger/go/v3`
+ * sit in the repo while every tag was `go/v4.x` — no v3 tag has ever existed,
+ * so `go get` could not resolve a single tagged release from v4.0.0 onward.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+
+const MODULE_BASE = "github.com/SmooAI/logger/go";
+
+/**
+ * @param {string} goModContent contents of go/go.mod
+ * @param {string} packageVersion the version field from package.json
+ * @returns {string[]} human-readable failures; empty means the guard passes
+ */
+export function checkGoModuleMajor(goModContent, packageVersion) {
+  const errors = [];
+
+  const moduleMatch = goModContent.match(/^module\s+(\S+)/m);
+  if (!moduleMatch) {
+    return [`go/go.mod has no \`module\` directive`];
+  }
+  const modulePath = moduleMatch[1];
+
+  const majorMatch = packageVersion.match(/^(\d+)\./);
+  if (!majorMatch) {
+    return [`package.json version "${packageVersion}" is not a semver version`];
+  }
+  const major = Number(majorMatch[1]);
+
+  // Go only requires (and only allows) a /vN suffix for major >= 2.
+  const expected = major >= 2 ? `${MODULE_BASE}/v${major}` : MODULE_BASE;
+
+  if (modulePath !== expected) {
+    errors.push(
+      `go/go.mod declares \`module ${modulePath}\` but package.json is at ${packageVersion}, ` +
+        `so release.yml will mint the tag \`go/v${packageVersion}\`. ` +
+        `Go resolves \`go/vN.x\` tags only for a module path ending in \`/v${major}\`, ` +
+        `so that tag would resolve nothing. Expected \`module ${expected}\`.`,
+    );
+  }
+
+  return errors;
+}
+
+// ponytail: no CLI arg parsing — the two paths are fixed by the repo layout.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const root = process.cwd();
+  const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+  const goMod = readFileSync(resolve(root, "go", "go.mod"), "utf8");
+
+  const errors = checkGoModuleMajor(goMod, pkg.version);
+  if (errors.length > 0) {
+    console.error("check-go-module: FAILED");
+    for (const error of errors) console.error(`  - ${error}`);
+    process.exit(1);
+  }
+  console.log(`check-go-module: OK (package.json ${pkg.version} matches the Go module path)`);
+}

--- a/scripts/check-go-module.spec.ts
+++ b/scripts/check-go-module.spec.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+// @ts-expect-error -- plain .mjs guard script, no types
+import { checkGoModuleMajor } from "./check-go-module.mjs";
+
+const root = resolve(__dirname, "..");
+const goMod = (path: string) => `module ${path}\n\ngo 1.25.0\n`;
+
+describe("checkGoModuleMajor", () => {
+  it("passes for the real repo state", () => {
+    const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+    const content = readFileSync(resolve(root, "go", "go.mod"), "utf8");
+    expect(checkGoModuleMajor(content, pkg.version)).toEqual([]);
+  });
+
+  it("fails on the /v3-module-vs-v4-tag mismatch that shipped for months", () => {
+    const errors = checkGoModuleMajor(goMod("github.com/SmooAI/logger/go/v3"), "4.3.0");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("/v4");
+  });
+
+  it("fails when the module carries a suffix but the package is pre-v2", () => {
+    expect(checkGoModuleMajor(goMod("github.com/SmooAI/logger/go/v4"), "1.2.3")).toHaveLength(1);
+  });
+
+  it("passes for a bare module path when the package is pre-v2", () => {
+    expect(checkGoModuleMajor(goMod("github.com/SmooAI/logger/go"), "1.2.3")).toEqual([]);
+  });
+
+  it("fails when a major bump leaves the module path behind", () => {
+    expect(checkGoModuleMajor(goMod("github.com/SmooAI/logger/go/v4"), "5.0.0")).toHaveLength(1);
+  });
+
+  it("fails loudly on a missing module directive", () => {
+    expect(checkGoModuleMajor("go 1.25.0\n", "4.3.0")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

```
go/go.mod:1:  module github.com/SmooAI/logger/go/v3
```

Every Go tag this repo has ever pushed is `go/v4.x`:

```
go/v4.1.3  go/v4.1.4  go/v4.1.8  go/v4.1.9  go/v4.1.10  go/v4.2.0  go/v4.3.0
```

**No `go/v3.*` tag has ever existed.** Go resolves a `go/vN.x` tag only for a module path ending in `/vN`, so `go get github.com/SmooAI/logger/go/v3@v4.3.0` resolves nothing. The Go port has been un-`go get`-able at a real version since v4.0.0 — the only thing that worked was a `main` pseudo-version, which is exactly what the README had to document:

> **Go note:** the module path is `…/go/v3`, so `go get` resolves a pseudo-version tracking `main` rather than a tagged release…

## What this does

- `go/go.mod` → `module github.com/SmooAI/logger/go/v4`. The Go package is flat (one `package logger`, no self-imports), so **no source imports changed** — verified with `grep -rn "SmooAI/logger/go"`; only `go.mod` and two READMEs referenced the path.
- Drops the "tag-scheme fix is tracked separately" note from `README.md` and updates both install lines and the pkg.go.dev badge.
- Adds **`scripts/check-go-module.mjs`** — the guard whose absence let this live for months. It parses the `/vN` suffix from `go.mod`, compares it to `package.json`'s major, and **exits 1** on mismatch.

## The guard runs twice, deliberately

| where | why |
| --- | --- |
| `pr-checks.yml`, before typecheck | fast feedback on a PR that edits either file |
| inside release.yml's *"Tag and publish Go module"* step | **the only place that actually matters** |

`changesets/action` bumps `package.json` *after* the pre-flight checks run, and the tag is minted from the post-bump version. A guard that only ran pre-flight would pass on the old version and then mint another unresolvable tag on any major bump. Guarding at the tagging step closes that.

## Verification

- `go build ./... && go vet ./... && go test ./...` → `ok github.com/SmooAI/logger/go/v4`
- `node scripts/check-go-module.mjs` → OK
- Hand-broke it back to `/v3` and confirmed red:
  ```
  check-go-module: FAILED
    - go/go.mod declares `module github.com/SmooAI/logger/go/v3` but package.json is at 4.3.0,
      so release.yml will mint the tag `go/v4.3.0`. Go resolves `go/vN.x` tags only for a module
      path ending in `/v4`, so that tag would resolve nothing.
  ```
- `scripts/check-go-module.spec.ts` — 6 cases, including the exact `/v3`-module-vs-`v4`-tag mismatch that shipped, the pre-v2 bare-path case, and a future major bump leaving the path behind.

## After merge

The release workflow mints `go/v4.3.1` from this changeset's patch bump; I'll verify against `proxy.golang.org` with a scratch module (`GOFLAGS=-mod=mod go get github.com/SmooAI/logger/go/v4@v4.3.1`) and report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152bbE1veqfG1SVJdyLCBxC