### PR TITLE
Add per-line caller location to the Rust and .NET ports

### DIFF
--- a/.changeset/caller-location-rust-dotnet.md
+++ b/.changeset/caller-location-rust-dotnet.md
@@ -1,0 +1,28 @@
+---
+"@smooai/logger": minor
+---
+
+Add per-line caller location to the Rust and .NET ports, closing the last two gaps in that row.
+
+Every entry from all five ports now says where it was emitted. Rust and .NET join Go's
+single-frame shape:
+
+```jsonc
+{ "caller": { "file": "UserService.cs", "line": 42, "function": "CreateUser" } }
+```
+
+- **.NET** uses `[CallerFilePath]` / `[CallerLineNumber]` / `[CallerMemberName]`, which the
+  compiler fills in at each call site — no `StackTrace` walk, so it costs nothing at runtime.
+  The three parameters are threaded down to `Emit` so the location is the *caller's* line and
+  not the one-line forwarder inside `SmooLogger`.
+- **Rust** uses `#[track_caller]` on the level methods, `do_log`, and `build_log_object`, so
+  `Location::caller()` resolves to your `logger.info(...)` line rather than a frame inside the
+  crate. `function` is absent: `std::panic::Location` carries no symbol name, and resolving one
+  would mean capturing a backtrace on every line.
+
+Both emit the file **basename** only — `[CallerFilePath]` and `Location::file()` expand to the
+absolute path on the build machine, which is noise and a mild leak.
+
+`ContextKey.Caller` is added to the .NET key set. Rust uses a module-level `CALLER_KEY` constant
+rather than a new `ContextKey` variant, since adding one to that public enum would break
+downstream exhaustive matches.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The ports are **not** all identical — the honest capability matrix is [below](
 | 🔗 | [**Correlation across services**](#-correlation-across-services) | All 5 languages |
 | ⚡ | [**AWS context, captured automatically**](#-aws-context-captured-automatically) | All 5 languages |
 | 🔭 | [**Logs that join your traces**](#-logs-that-join-your-traces) | TS · Python · Rust · Go (+ .NET via `Activity`) |
-| 📍 | [**Exact caller location**](#-exact-caller-location) | TS · Python · Go |
+| 📍 | [**Exact caller location**](#-exact-caller-location) | All 5 languages |
 | 🎨 | [**Pretty local output + rotating file logs**](#-pretty-local-output--rotating-file-logs) | All 5 languages |
 | 🕶️ | [**Sensitive-key redaction**](#-sensitive-key-redaction) | All 5 languages |
 | 🖥️ | [**Browser logging**](#-browser-logging) | TypeScript only |
@@ -150,7 +150,7 @@ Each port depends only on the OTel **API** (no SDK, no exporter). **.NET is the 
 
 ### 📍 Exact caller location
 
-In **TypeScript, Python, and Go**, every entry includes where in the code it was emitted:
+Every entry includes where in the code it was emitted, in all five languages:
 
 ```jsonc
 {
@@ -163,7 +163,22 @@ In **TypeScript, Python, and Go**, every entry includes where in the code it was
 }
 ```
 
-(Go emits a single-frame `caller` object — file, line, function — rather than a stack.) The **Rust and .NET ports do not capture per-line caller location today**; both serialize full stack traces for logged *errors*.
+Two shapes are in play, and the difference is deliberate:
+
+| shape | ports | how |
+| --- | --- | --- |
+| `callerContext.stack` — multiple frames | TypeScript, Python | walks the runtime stack |
+| `caller: { file, line, function }` — one frame | Go, Rust, .NET | zero-cost compile-time / `runtime.Caller` |
+
+```jsonc
+{ "caller": { "file": "UserService.cs", "line": 42, "function": "CreateUser" } }
+```
+
+Rust omits `function`: `#[track_caller]` gives file and line for free, but `std::panic::Location`
+carries no symbol name and resolving one would mean capturing a backtrace on every line. .NET uses
+`[CallerFilePath]`/`[CallerLineNumber]`/`[CallerMemberName]`, which the compiler fills in at each
+call site — no `StackTrace` walk. Both emit the file **basename** only; the full path is
+build-machine noise.
 
 ### 🎨 Pretty local output + rotating file logs
 
@@ -259,12 +274,13 @@ The wire schema is shared; port depth is not identical. Here's the honest status
 | Rotating file logs (`.smooai-logs/`) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Sensitive-key redaction | ✅ | ✅ | ✅ | ✅ | ✅ |
 | OTel span → `traceId`/`spanId` stamping | ✅ | ✅ | ✅ | ✅ | ➖ ² |
-| Per-line caller location | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Per-line caller location ⁴ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Browser logger | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Parity corpus enforced in tests ³ | ✅ | ✅ | ❌ | ❌ | ❌ |
 
 ¹ Behind the `aws-lambda` cargo feature; Lambda *environment* context needs no feature.
-² No OTel dependency — equivalent real W3C trace/span IDs read from `System.Diagnostics.Activity.Current`.
+² No OTel dependency — equivalent real W3C trace/span IDs read from `System.Diagnostics.Activity.Current`, which is the API OpenTelemetry .NET itself builds on. Log lines also tee upstream via `SmooLoggerOptions.ForwardTo` (an `ILogger`), the hook OTel's .NET log appender attaches to.
+⁴ Two shapes: TypeScript and Python emit a multi-frame `callerContext.stack`; Go, Rust and .NET emit a single-frame `caller` object. Rust's omits `function` — see [Exact caller location](#-exact-caller-location).
 ³ [`parity-corpus.json`](parity-corpus.json) is the cross-language output contract, but today only the TypeScript ([`src/parity-corpus.spec.ts`](src/parity-corpus.spec.ts)) and Python ([`python/tests/test_parity_corpus.py`](python/tests/test_parity_corpus.py)) suites replay it. The Rust, Go, and .NET ports aim at the same schema and have their own test suites, but their conformance is **not** yet machine-checked against the corpus.
 
 **CI does cover all five languages on every PR** ([`pr-checks.yml`](.github/workflows/pr-checks.yml) typechecks, lints, tests, and builds TS, Python, Rust, Go, and .NET), and [`release.yml`](.github/workflows/release.yml) publishes all five: npm → PyPI → crates.io → Go module tag → NuGet.

--- a/dotnet/src/SmooAI.Logger/LogContext.cs
+++ b/dotnet/src/SmooAI.Logger/LogContext.cs
@@ -14,6 +14,8 @@ public static class ContextKey
     public const string Message = "msg";
     public const string ErrorDetails = "errorDetails";
 
+    /// <summary>Single-frame caller location: <c>{ file, line, function }</c>. Matches the Go port.</summary>
+    public const string Caller = "caller";
     public const string Name = "name";
     public const string CorrelationId = "correlationId";
     public const string User = "user";

--- a/dotnet/src/SmooAI.Logger/README.md
+++ b/dotnet/src/SmooAI.Logger/README.md
@@ -17,7 +17,8 @@ dotnet add package SmooAI.Logger
 
 - **Correlation across services** — a single `correlationId` flows through HTTP calls, SQS records, and background tasks so you can grep one ID and see the whole request.
 - **Typed user + request + response fields** — no more stringly-typed `["user_id"] = user.Id`. Push a `User`, `HttpRequest`, or `HttpResponse` and the logger serializes every relevant field.
-- **Full error stack traces** — logged exceptions carry their type, message, and stack trace. (Per-line caller location, present in the TS/Python/Go ports, is not captured by the .NET port today.)
+- **Full error stack traces** — logged exceptions carry their type, message, and stack trace.
+- **Per-line caller location** — every entry carries `caller: { file, line, function }`, filled in by the compiler via `[CallerFilePath]` / `[CallerLineNumber]` / `[CallerMemberName]`. No `StackTrace` walk, so it costs nothing at runtime. Only the file basename is emitted; the full path is build-machine noise. (This is the Go port's single-frame shape; TypeScript and Python emit a multi-frame `callerContext.stack` instead.)
 - **Structured by default** — strict JSON lines in production, ANSI pretty-print locally.
 - **Wire-compatible with every other SmooAI.Logger port** — the schema is the same in TS, Python, Go, and Rust, so distributed traces stitch together across language boundaries.
 - **Works with `Microsoft.Extensions.Logging`** — forward to Serilog, AWS.Logger, or any `ILogger` sink without losing structure.

--- a/dotnet/src/SmooAI.Logger/SmooLogger.cs
+++ b/dotnet/src/SmooAI.Logger/SmooLogger.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 
 namespace SmooAI.Logger;
@@ -374,29 +375,42 @@ public class SmooLogger : IDisposable
 
     public bool IsEnabled(Level level) => level >= MinLevel;
 
-    public void LogTrace(string message, object? data = null, Exception? error = null)
-        => Emit(Level.Trace, message, data, error);
+    // The three `caller*` parameters are filled in by the compiler at each call
+    // site (they are never passed explicitly), so per-line caller location costs
+    // nothing at runtime — no StackTrace walk. They are threaded down to Emit so
+    // the location recorded is the USER's call site, not this one-line forwarder.
 
-    public void LogDebug(string message, object? data = null, Exception? error = null)
-        => Emit(Level.Debug, message, data, error);
+    public void LogTrace(string message, object? data = null, Exception? error = null,
+        [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = 0, [CallerMemberName] string? callerMember = null)
+        => Emit(Level.Trace, message, data, error, callerFile, callerLine, callerMember);
 
-    public void LogInfo(string message, object? data = null, Exception? error = null)
-        => Emit(Level.Info, message, data, error);
+    public void LogDebug(string message, object? data = null, Exception? error = null,
+        [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = 0, [CallerMemberName] string? callerMember = null)
+        => Emit(Level.Debug, message, data, error, callerFile, callerLine, callerMember);
 
-    public void LogWarning(string message, object? data = null, Exception? error = null)
-        => Emit(Level.Warn, message, data, error);
+    public void LogInfo(string message, object? data = null, Exception? error = null,
+        [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = 0, [CallerMemberName] string? callerMember = null)
+        => Emit(Level.Info, message, data, error, callerFile, callerLine, callerMember);
 
-    public void LogError(string message, object? data = null, Exception? error = null)
-        => Emit(Level.Error, message, data, error);
+    public void LogWarning(string message, object? data = null, Exception? error = null,
+        [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = 0, [CallerMemberName] string? callerMember = null)
+        => Emit(Level.Warn, message, data, error, callerFile, callerLine, callerMember);
 
-    public void LogFatal(string message, object? data = null, Exception? error = null)
-        => Emit(Level.Fatal, message, data, error);
+    public void LogError(string message, object? data = null, Exception? error = null,
+        [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = 0, [CallerMemberName] string? callerMember = null)
+        => Emit(Level.Error, message, data, error, callerFile, callerLine, callerMember);
+
+    public void LogFatal(string message, object? data = null, Exception? error = null,
+        [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = 0, [CallerMemberName] string? callerMember = null)
+        => Emit(Level.Fatal, message, data, error, callerFile, callerLine, callerMember);
 
     /// <summary>Primary entry point — emit a structured log at the given level.</summary>
-    public void Log(Level level, string message, object? data = null, Exception? error = null)
-        => Emit(level, message, data, error);
+    public void Log(Level level, string message, object? data = null, Exception? error = null,
+        [CallerFilePath] string? callerFile = null, [CallerLineNumber] int callerLine = 0, [CallerMemberName] string? callerMember = null)
+        => Emit(level, message, data, error, callerFile, callerLine, callerMember);
 
-    private void Emit(Level level, string message, object? data, Exception? error)
+    private void Emit(Level level, string message, object? data, Exception? error,
+        string? callerFile = null, int callerLine = 0, string? callerMember = null)
     {
         if (!IsEnabled(level))
         {
@@ -438,6 +452,19 @@ public class SmooLogger : IDisposable
         {
             entry[ContextKey.TraceId] = activity.TraceId.ToHexString();
             entry[ContextKey.SpanId] = activity.SpanId.ToHexString();
+        }
+
+        // Per-line caller location, matching the Go port's single-frame `caller`
+        // object. Only the file NAME is emitted: [CallerFilePath] expands to the
+        // absolute path on the BUILD machine, which is both noise and a leak.
+        if (!string.IsNullOrEmpty(callerFile))
+        {
+            entry[ContextKey.Caller] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["file"] = Path.GetFileName(callerFile),
+                ["line"] = callerLine,
+                ["function"] = callerMember,
+            };
         }
 
         entry[ContextKey.Level] = (int)level;

--- a/dotnet/tests/SmooAI.Logger.Tests/CallerLocationTests.cs
+++ b/dotnet/tests/SmooAI.Logger.Tests/CallerLocationTests.cs
@@ -1,0 +1,87 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+
+namespace SmooAI.Logger.Tests;
+
+/// <summary>
+/// Per-line caller location (<c>caller: { file, line, function }</c>).
+///
+/// The value is not "a caller field exists" but that it points at the USER's
+/// call site rather than a frame inside SmooLogger — which is what threading the
+/// compiler-injected <c>[Caller*]</c> arguments down to <c>Emit</c> buys.
+/// </summary>
+public class CallerLocationTests
+{
+    private static (SmooLogger Logger, StringWriter Out) Build()
+    {
+        var writer = new StringWriter();
+        return (new SmooLogger(new SmooLoggerOptions
+        {
+            Output = writer,
+            PrettyPrint = false,
+            Name = "caller-test",
+            Level = Level.Trace,
+        }), writer);
+    }
+
+    private static JsonElement ParseSingle(StringWriter writer) =>
+        JsonDocument.Parse(writer.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries)[0]).RootElement.Clone();
+
+    [Fact]
+    public void Caller_Points_At_This_File_Line_And_Method()
+    {
+        var (logger, writer) = Build();
+
+        // Keep these two statements adjacent — the assertion pins the emitted
+        // line to the LogInfo call, so an edit between them fails.
+        var expectedLine = CurrentLine() + 1;
+        logger.LogInfo("hello");
+
+        var caller = ParseSingle(writer).GetProperty("caller");
+        Assert.Equal("CallerLocationTests.cs", caller.GetProperty("file").GetString());
+        Assert.Equal(expectedLine, caller.GetProperty("line").GetInt32());
+        Assert.Equal(nameof(Caller_Points_At_This_File_Line_And_Method), caller.GetProperty("function").GetString());
+    }
+
+    [Fact]
+    public void Caller_File_Is_The_Basename_Not_The_Build_Machine_Path()
+    {
+        var (logger, writer) = Build();
+        logger.LogWarning("hello");
+
+        var file = ParseSingle(writer).GetProperty("caller").GetProperty("file").GetString()!;
+        Assert.DoesNotContain(Path.DirectorySeparatorChar, file);
+        Assert.DoesNotContain('/', file);
+    }
+
+    [Fact]
+    public void Caller_Tracks_The_Call_Site_Not_A_Fixed_Library_Frame()
+    {
+        var (logger, writer) = Build();
+        logger.LogInfo("one");
+        logger.LogInfo("two");
+
+        var lines = writer.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => JsonDocument.Parse(l).RootElement.GetProperty("caller").GetProperty("line").GetInt32())
+            .ToArray();
+
+        Assert.Equal(2, lines.Length);
+        // A constant here would mean the location is read from a frame inside SmooLogger.
+        Assert.Equal(1, lines[1] - lines[0]);
+    }
+
+    [Fact]
+    public void Every_Level_Carries_Caller()
+    {
+        foreach (var level in new[] { Level.Trace, Level.Debug, Level.Info, Level.Warn, Level.Error, Level.Fatal })
+        {
+            var (logger, writer) = Build();
+            logger.Log(level, "hello");
+            var caller = ParseSingle(writer).GetProperty("caller");
+            Assert.Equal("CallerLocationTests.cs", caller.GetProperty("file").GetString());
+            Assert.True(caller.GetProperty("line").GetInt32() > 0);
+        }
+    }
+
+    private static int CurrentLine([CallerLineNumber] int line = 0) => line;
+}

--- a/rust/logger/Cargo.toml
+++ b/rust/logger/Cargo.toml
@@ -41,6 +41,8 @@ opentelemetry = { version = "0.32.0", default-features = false, features = ["tra
 
 [dev-dependencies]
 tempfile = "3"
+# The caller-location test inspects the built record as raw JSON.
+serde_json = { version = "1", features = ["preserve_order"] }
 # Correlation + tee tests: a real SDK tracer to mint an active span, and a
 # tracing subscriber to capture the teed events (dev-only — the SDK dep is not
 # circular; the crate itself depends on the OTel API only).

--- a/rust/logger/README.md
+++ b/rust/logger/README.md
@@ -79,7 +79,12 @@ cargo add smooai-logger
 
 ## The Power of Automatic Context
 
-> **Note:** unlike the TypeScript, Python, and Go ports, the Rust port does **not** capture per-line caller location (`callerContext`) today. Stack traces are serialized for logged *errors*.
+> **Note:** every entry carries per-line caller location as `caller: { file, line }`, captured via
+> `#[track_caller]` on the level methods, so it points at your `logger.info(...)` line rather than a
+> frame inside this crate. Only the file basename is emitted. `function` is absent: `std::panic::Location`
+> carries no symbol name and resolving one would mean capturing a backtrace on every line — Go and .NET
+> do include it. TypeScript and Python emit a multi-frame `callerContext.stack` instead of this
+> single-frame shape. Full stack traces are still serialized for logged *errors*.
 
 ### Track Requests Across Services
 

--- a/rust/logger/src/logger.rs
+++ b/rust/logger/src/logger.rs
@@ -16,6 +16,11 @@ use crate::context::{
 };
 use crate::env::{is_build, is_local};
 use crate::error::{log_error, LoggedError};
+
+/// Wire key for the single-frame caller location. Matches the Go port's literal;
+/// deliberately not a `ContextKey` variant, since adding one to that public enum
+/// would break downstream exhaustive matches.
+const CALLER_KEY: &str = "caller";
 use crate::pretty;
 use crate::rotation::{RotatingFileWriter, RotationOptions};
 
@@ -350,6 +355,10 @@ impl Logger {
         Url::parse(origin).ok().and_then(|url| url.host_str().map(|host| host.to_string()))
     }
 
+    /// `#[track_caller]` here and on `do_log` / the level methods makes
+    /// `Location::caller()` resolve to the USER's `logger.info(...)` line rather
+    /// than to a frame inside this crate.
+    #[track_caller]
     pub fn build_log_object(&self, level: Level, args: &LogArgs) -> Value {
         let mut payload = context::global_context();
         if !payload.is_object() {
@@ -395,6 +404,17 @@ impl Logger {
             Value::String(Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)),
         );
         map.insert(ContextKey::Name.as_str().into(), Value::String(self.name.clone()));
+
+        // Per-line caller location, matching the Go port's single-frame `caller`
+        // object. Only the file NAME is emitted (the full path is build-machine
+        // noise). `function` is absent: `Location` carries no symbol name, and
+        // resolving one would mean capturing a backtrace on every line.
+        let location = std::panic::Location::caller();
+        let file = location.file().rsplit(['/', '\\']).next().unwrap_or(location.file());
+        let mut caller = Map::new();
+        caller.insert("file".into(), Value::String(file.to_string()));
+        caller.insert("line".into(), Value::Number(serde_json::Number::from(u64::from(location.line()))));
+        map.insert(CALLER_KEY.into(), Value::Object(caller));
 
         // Correlate this line to the active trace: when an OpenTelemetry span is
         // active, override the fabricated `traceId` with the span's real W3C
@@ -464,6 +484,7 @@ impl Logger {
         }
     }
 
+    #[track_caller]
     fn do_log(&self, level: Level, args: LogArgs) -> io::Result<()> {
         let payload = self.build_log_object(level, &args);
         self.tee_to_tracing(level, &payload);
@@ -474,6 +495,7 @@ impl Logger {
         level.code() >= self.level.code()
     }
 
+    #[track_caller]
     pub fn trace<A: Into<LogArgs>>(&self, args: A) -> io::Result<()> {
         if self.is_enabled(Level::Trace) {
             self.do_log(Level::Trace, args.into())
@@ -482,6 +504,7 @@ impl Logger {
         }
     }
 
+    #[track_caller]
     pub fn debug<A: Into<LogArgs>>(&self, args: A) -> io::Result<()> {
         if self.is_enabled(Level::Debug) {
             self.do_log(Level::Debug, args.into())
@@ -490,6 +513,7 @@ impl Logger {
         }
     }
 
+    #[track_caller]
     pub fn info<A: Into<LogArgs>>(&self, args: A) -> io::Result<()> {
         if self.is_enabled(Level::Info) {
             self.do_log(Level::Info, args.into())
@@ -498,6 +522,7 @@ impl Logger {
         }
     }
 
+    #[track_caller]
     pub fn warn<A: Into<LogArgs>>(&self, args: A) -> io::Result<()> {
         if self.is_enabled(Level::Warn) {
             self.do_log(Level::Warn, args.into())
@@ -506,6 +531,7 @@ impl Logger {
         }
     }
 
+    #[track_caller]
     pub fn error<A: Into<LogArgs>>(&self, args: A) -> io::Result<()> {
         if self.is_enabled(Level::Error) {
             self.do_log(Level::Error, args.into())
@@ -514,6 +540,7 @@ impl Logger {
         }
     }
 
+    #[track_caller]
     pub fn fatal<A: Into<LogArgs>>(&self, args: A) -> io::Result<()> {
         if self.is_enabled(Level::Fatal) {
             self.do_log(Level::Fatal, args.into())

--- a/rust/logger/tests/caller_location.rs
+++ b/rust/logger/tests/caller_location.rs
@@ -1,0 +1,73 @@
+//! Per-line caller location (`caller: { file, line }`).
+//!
+//! The value that matters is not "a caller field exists" but that it points at
+//! the USER's call site rather than a frame inside this crate — which is exactly
+//! what `#[track_caller]` on the level methods buys.
+
+use smooai_logger::{Level, LogArgs, Logger, LoggerOptions};
+
+fn test_logger() -> Logger {
+    let logger = Logger::new(LoggerOptions {
+        name: Some("CallerTest".into()),
+        log_to_file: Some(false),
+        ..Default::default()
+    });
+    logger.reset_context();
+    logger
+}
+
+fn args(message: &str) -> LogArgs {
+    let mut args = LogArgs::new();
+    args.push(message.to_string());
+    args
+}
+
+#[test]
+fn caller_points_at_this_file_and_the_calling_line() {
+    let logger = test_logger();
+
+    // Keep these two statements adjacent: the assertion below pins the emitted
+    // line number to the `build_log_object` call, so an edit between them fails.
+    let expected_line = line!() + 1;
+    let record = logger.build_log_object(Level::Info, &args("hello"));
+
+    let caller = record["caller"].as_object().expect("every record carries `caller`");
+    assert_eq!(
+        caller["file"].as_str(),
+        Some("caller_location.rs"),
+        "file must be the basename, not the build-machine absolute path"
+    );
+    assert_eq!(caller["line"].as_u64(), Some(u64::from(expected_line)));
+}
+
+#[test]
+fn caller_tracks_the_call_site_not_a_fixed_crate_frame() {
+    let logger = test_logger();
+
+    let first = logger.build_log_object(Level::Info, &args("one"));
+    let second = logger.build_log_object(Level::Info, &args("two"));
+
+    let line_of = |record: &serde_json::Value| record["caller"]["line"].as_u64().unwrap();
+    assert_eq!(
+        line_of(&second) - line_of(&first),
+        1,
+        "two adjacent calls must report adjacent lines; a constant here would mean \
+         the location is being read from a frame inside the crate"
+    );
+}
+
+/// A helper one frame deeper: without `#[track_caller]` on the level methods the
+/// location would resolve inside `logger.rs` for every one of these.
+fn log_from_helper(logger: &Logger) -> serde_json::Value {
+    logger.build_log_object(Level::Warn, &args("from helper"))
+}
+
+#[test]
+fn caller_resolves_through_a_user_helper() {
+    let record = log_from_helper(&test_logger());
+    let caller = record["caller"].as_object().unwrap();
+    assert_eq!(caller["file"].as_str(), Some("caller_location.rs"));
+    // The helper's own body, not the test that called it — `Location::caller()`
+    // is the immediate caller, and `log_from_helper` is not `#[track_caller]`.
+    assert!(caller["line"].as_u64().unwrap() > 0);
+}


### PR DESCRIPTION
## Scope note — one of the two assigned gaps turned out not to exist

The task listed two .NET gaps. **Only one is real**, and I did not "fix" the other:

> ❌ *"OTel span correlation landed in TS/Python/Rust/Go; .NET correlates via `System.Diagnostics.Activity` instead and has no OTel path."*

`System.Diagnostics.Activity` **is** the OpenTelemetry API for .NET. OpenTelemetry .NET does not ship its own span type — `ActivitySource`/`Activity` *are* the tracing API, and `Activity.Current` is the active OTel span. `SmooLogger` already does the right thing:

```csharp
var activity = System.Diagnostics.Activity.Current;
if (activity is not null && activity.IdFormat == ActivityIdFormat.W3C)
{
    entry[ContextKey.TraceId] = activity.TraceId.ToHexString();
    entry[ContextKey.SpanId] = activity.SpanId.ToHexString();
}
```

Those are the same real W3C IDs the other four ports read. Adding an `OpenTelemetry.Api` package reference would add a dependency that reads `Activity.Current` on our behalf — strictly worse.

The log-tee half is covered too: `SmooLoggerOptions.ForwardTo` forwards each structured entry to an upstream `ILogger`, which is the .NET equivalent of Rust's `tracing` tee, and `ILoggerFactory` is exactly what OTel's .NET log appender hooks.

The README footnote already said this correctly. I've extended it to mention the `ForwardTo` tee, and left the code alone.

## What this PR actually does

The **caller-location** gap was real. Both port READMEs said so:

> *rust/logger/README.md*: "unlike the TypeScript, Python, and Go ports, the Rust port does **not** capture per-line caller location today."
> *dotnet/.../README.md*: "Per-line caller location … is not captured by the .NET port today."

Both now do, joining Go's single-frame shape:

```jsonc
{ "caller": { "file": "UserService.cs", "line": 42, "function": "CreateUser" } }
```

### .NET — `[Caller*]` attributes, zero runtime cost

`[CallerFilePath]` / `[CallerLineNumber]` / `[CallerMemberName]` are filled in by the **compiler** at each call site. No `StackTrace` walk.

The subtlety: they are threaded down into `Emit` rather than captured there. `LogInfo` is a one-line forwarder, so capturing inside `Emit` would make every record point at `SmooLogger.cs` instead of the user's code.

### Rust — `#[track_caller]` on the whole chain

`#[track_caller]` on the six level methods, `do_log`, **and** `build_log_object`. The attribute has to be on the entire chain: `Location::caller()` reports the outermost non-`track_caller` frame, which is precisely the user's `logger.info(...)` line.

`function` is deliberately absent. `std::panic::Location` carries file, line, and column but no symbol name; getting one means capturing a backtrace on every emitted line. Documented in the Rust README and the README's parity footnote.

Both ports emit the file **basename** only — `[CallerFilePath]` and `Location::file()` both expand to the absolute path on the *build* machine, which is noise and a mild path leak.

## Tests assert the thing that matters

Not "a `caller` key exists" — that a `caller` key which always says `SmooLogger.cs:448` would pass. These pin that it tracks the *call site*:

- two adjacent calls report **adjacent** lines (a constant difference of 0 would mean the location is being read from a fixed frame inside the library);
- the exact line is pinned against `line!()` (Rust) and a `[CallerLineNumber]` helper (.NET);
- the file has **no** path separator in it;
- Rust: resolving through a user helper one frame deeper;
- .NET: every one of the six levels carries it.

## Verification

- Rust: `cargo test` → 15 + 3 + 4 + 1 passing across four binaries; `cargo clippy --all-targets -- -D warnings` clean.
- .NET: `dotnet test -c Release` → **39/39** across net8.0/9.0/10.0.
- READMEs updated: the feature-tour row, the "Exact caller location" section (now with the two-shapes table), the parity matrix row `❌ ❌` → `✅ ✅` with a new footnote ⁴, plus both per-language READMEs.

## Follow-up worth a ticket, not this PR

The two caller shapes are genuinely divergent: TypeScript and Python emit multi-frame `callerContext.stack`, while Go, Rust and .NET emit single-frame `caller`. Unifying them is a **breaking wire change** for every existing consumer of either field, so it needs a decision rather than a drive-by. Documented honestly in the README for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152bbE1veqfG1SVJdyLCBxC