### PR TITLE
Sync the non-npm manifests to 4.5.1 (one-time, unblocks the release)

### DIFF
--- a/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
+++ b/dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <PackageId>SmooAI.Logger</PackageId>
-    <Version>4.5.0</Version>
+    <Version>4.5.1</Version>
     <Authors>SmooAI</Authors>
     <Company>SmooAI</Company>
     <Description>Contextual structured logger for AWS and server environments. .NET port of @smooai/logger — wraps Microsoft.Extensions.Logging.ILogger with correlation IDs, HTTP request/response context, user context, and structured JSON output.</Description>

--- a/go/version.go
+++ b/go/version.go
@@ -1,4 +1,4 @@
 package logger
 
 // Version is the current version of the smooai-logger Go package.
-const Version = "4.5.0"
+const Version = "4.5.1"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smooai-logger"
-version = "4.5.0"
+version = "4.5.1"
 description = "Context-aware structured logging utilities for Python that mirror the @smooai/logger toolkit."
 readme = "README.md"
 authors = [{ name = "SmooAI", email = "brent@smooai.com" }]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -354,7 +354,7 @@ wheels = [
 
 [[package]]
 name = "smooai-logger"
-version = "4.5.0"
+version = "4.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "colorist" },

--- a/rust/logger/Cargo.lock
+++ b/rust/logger/Cargo.lock
@@ -1166,7 +1166,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smooai-logger"
-version = "4.5.0"
+version = "4.5.1"
 dependencies = [
  "aws_lambda_events",
  "chrono",

--- a/rust/logger/Cargo.toml
+++ b/rust/logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smooai-logger"
-version = "4.5.0"
+version = "4.5.1"
 edition = "2021"
 description = "Context-aware structured logging utilities for Rust mirroring the @smooai/logger toolkit."
 license = "MIT"


### PR DESCRIPTION
## What happened

The release that bumped `package.json` to `4.5.1` ran from the commit **before** the version-sync fix (#186) landed, so it used the old plain `changeset version` with no sync. The next release run then hit the new guard and stopped:

```
check-versions: FAILED — manifests disagree with package.json (4.5.1)
  - python/pyproject.toml is at 4.5.0, expected 4.5.1 (package.json)
  - python/uv.lock is at 4.5.0, expected 4.5.1 (package.json)
  - rust/logger/Cargo.toml is at 4.5.0, expected 4.5.1 (package.json)
  - rust/logger/Cargo.lock is at 4.5.0, expected 4.5.1 (package.json)
  - go/version.go is at 4.5.0, expected 4.5.1 (package.json)
  - dotnet/src/SmooAI.Logger/SmooAI.Logger.csproj is at 4.5.0, expected 4.5.1 (package.json)
```

**That is the guard doing its job, not a regression.** `main` genuinely carries a `package.json` bump that never reached the other five manifests — the exact defect #186 exists to stop, caught on the last bump the old flow could produce.

This is a one-time transition. From here `pnpm run version` is `changeset version && node scripts/sync-versions.mjs`, and `changesets/action` commits the whole working tree after the version command, so the synced manifests ride along inside the bump commit.

## Why no changeset

`4.5.1` was **never published** — the failing guard skipped every publish step (npm, PyPI, crates.io, the Go tag, NuGet were all `skipped`). Merging this lets the release finish `4.5.1` consistently across all five registries.

Adding a changeset would bump to `4.5.2` and strand `4.5.1` in the changelog with nothing published under it. No code changes here, only version metadata.

## Verification

- `node scripts/check-versions.mjs` → `OK (all manifests at 4.5.1)`
- `uv sync --locked --group dev` clean (this is why `uv.lock` had to be in the synced set — it errors outright on a stale lock)
- `cargo check --locked` clean, so `cargo publish --locked` will be too

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152bbE1veqfG1SVJdyLCBxC