### PR TITLE
Stop the release reporting failure when the changeset PR is already green

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,13 +171,37 @@ jobs:
         run: |
           PR_NUMBER=$(gh pr list --state open --head changeset-release/main --json number --jq '.[0].number')
 
-          if [[ -n "$PR_NUMBER" && "$PR_NUMBER" != "null" ]]; then
-            echo "Found Changeset PR #$PR_NUMBER, attempting to auto-merge..."
-            gh pr merge "$PR_NUMBER" --auto --squash
+          if [[ -z "$PR_NUMBER" || "$PR_NUMBER" == "null" ]]; then
+            echo "No open Changeset PR found, skipping merge."
+            exit 0
+          fi
+
+          echo "Found Changeset PR #$PR_NUMBER, attempting to auto-merge..."
+
+          # `--auto` queues the merge behind pending checks, but GitHub REFUSES to
+          # enable it once a PR is already green:
+          #   GraphQL: Pull request is in clean status (enablePullRequestAutoMerge)
+          # That used to be unreachable because PR checks took ~20 minutes; they now
+          # take ~2, so the changeset PR is routinely green before this step runs and
+          # the whole release run reports failure even though it published fine.
+          # Fall back to merging outright — but only after confirming the checks are
+          # green, so this never merges over a red lane.
+          if gh pr merge "$PR_NUMBER" --auto --squash; then
             # The merge push automatically triggers the Release workflow
             # so no need to manually re-trigger it
-          else
-            echo "No open Changeset PR found, skipping merge."
+            exit 0
           fi
+
+          echo "Auto-merge was refused; checking whether #$PR_NUMBER is already green."
+          # Deliberately NOT `gh pr checks --required`: this repo has no required
+          # checks configured, so that would return an empty list and read as green.
+          # Every lane must be pass/skipping, and there must be at least one.
+          BUCKETS=$(gh pr checks "$PR_NUMBER" --json bucket --jq '[.[].bucket] | join(" ")' || echo "")
+          echo "Check buckets: [$BUCKETS]"
+          if [[ -z "$BUCKETS" ]] || [[ -n "$(tr ' ' '\n' <<<"$BUCKETS" | grep -vx -e pass -e skipping)" ]]; then
+            echo "::error::Changeset PR #$PR_NUMBER is not green ([$BUCKETS]); refusing to merge."
+            exit 1
+          fi
+          gh pr merge "$PR_NUMBER" --squash
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
## Problem

The last step of every release run is:

```bash
gh pr merge "$PR_NUMBER" --auto --squash
```

GitHub **refuses to enable auto-merge on a PR that is already mergeable**:

```
GraphQL: Pull request is in clean status (enablePullRequestAutoMerge)
```

So the release run reports **failure** after it has already versioned, published, and tagged successfully. That is the worst kind of red — everything shipped, the status says it didn't, and people learn to ignore the badge.

Seen live on [run 32404388603](https://github.com/SmooAI/logger/actions/runs/32404388603): `Guard`, `Typecheck`, `Lint`, `Test`, `Build`, `Format`, `Version Update 🦋` all ✅ — then `Auto-Merge Changeset PR` ❌ and the run is failed.

## Why now

This was unreachable by accident of timing. PR checks took **~20 minutes**, so the changeset PR was always still pending when this step ran and `--auto` had something to queue behind. Retiring the log-viewer crate (#180) cut PR checks to **~2 minutes**, so the changeset PR is now routinely green first and the race inverted.

## Fix

Fall back to a plain `--squash` when `--auto` is refused — but only after confirming the PR is actually green.

```bash
BUCKETS=$(gh pr checks "$PR_NUMBER" --json bucket --jq '[.[].bucket] | join(" ")' || echo "")
if [[ -z "$BUCKETS" ]] || [[ -n "$(tr ' ' '\n' <<<"$BUCKETS" | grep -vx -e pass -e skipping)" ]]; then
  echo "::error::Changeset PR #$PR_NUMBER is not green ([$BUCKETS]); refusing to merge."
  exit 1
fi
gh pr merge "$PR_NUMBER" --squash
```

**It deliberately does not use `gh pr checks --required`.** This repo has **no required checks configured**, so `--required` returns an empty list, the grep finds nothing, and it reads as green — a guard that checks the wrong thing and fails open on a merge. An empty bucket list is therefore treated as *not* green.

Truth table, run locally against the exact expression:

| buckets | result |
| --- | --- |
| `pass` | MERGE |
| `pass pass` | MERGE |
| `skipping pass` | MERGE |
| *(empty)* | REFUSE |
| `pass fail` | REFUSE |
| `pass pending` | REFUSE |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152bbE1veqfG1SVJdyLCBxC