### PR TITLE
Bump uuid, gate publishes per-registry, and stop Go caching the corpus

### DIFF
--- a/.changeset/uuid-bump-and-release-gating.md
+++ b/.changeset/uuid-bump-and-release-gating.md
@@ -1,0 +1,19 @@
+---
+"@smooai/logger": patch
+---
+
+Bump `uuid` to `^11.1.1`, gate each registry publish on that registry, and stop Go caching the parity corpus.
+
+- **`uuid` 9.0.1 → 11.1.1.** The moderate advisory (missing buffer bounds check in v3/v5/v6 when
+  `buf` is provided) is **not reachable** here — logger only ever calls `v4()` with no arguments —
+  but every consumer of `@smooai/logger` was inheriting the advisory and having to carry its own
+  `pnpm.overrides` pin. Fixed at the source instead. `@types/uuid` dropped; uuid 11 ships its own.
+- **Publish steps no longer gate on `steps.changesets.outputs.published`.** That output is true only
+  when the publish command shipped something *in that run*, so a run that died after npm left the
+  other four behind — and the follow-up run, with no changesets left, reported `published=false`,
+  skipped all four, and went **green having published nothing**. That is exactly how 4.5.1 and
+  4.5.2 stranded crates.io, NuGet and the Go tag at 4.5.0. Each step now asks its own registry
+  whether the version is already there, which also lets a re-run heal a partial release.
+- **`go:test` gains `-count=1`.** Go currently refuses to cache `parity_corpus_test.go` because it
+  reads `../parity-corpus.json` from outside the package dir — verified — but a parity guarantee
+  should not rest on that.

--- a/.changeset/uuid-bump-and-release-gating.md
+++ b/.changeset/uuid-bump-and-release-gating.md
@@ -9,7 +9,7 @@ Bump `uuid` to `^11.1.1`, gate each registry publish on that registry, and stop 
   but every consumer of `@smooai/logger` was inheriting the advisory and having to carry its own
   `pnpm.overrides` pin. Fixed at the source instead. `@types/uuid` dropped; uuid 11 ships its own.
 - **Publish steps no longer gate on `steps.changesets.outputs.published`.** That output is true only
-  when the publish command shipped something *in that run*, so a run that died after npm left the
+  when the publish command shipped something _in that run_, so a run that died after npm left the
   other four behind — and the follow-up run, with no changesets left, reported `published=false`,
   skipped all four, and went **green having published nothing**. That is exactly how 4.5.1 and
   4.5.2 stranded crates.io, NuGet and the Go tag at 4.5.0. Each step now asks its own registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,43 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           NPM_TOKEN: ${{ secrets.SMOOAI_NPM_TOKEN }}
 
+      # Gate each registry on whether IT is behind, not on whether npm published
+      # in THIS run. `steps.changesets.outputs.published` is only true when the
+      # publish command actually shipped something, so a run that died after npm
+      # left PyPI/crates.io/Go/NuGet behind, and the NEXT run had no changesets
+      # left, reported published=false, skipped all four, and went GREEN having
+      # published nothing. That is how 4.5.1 and 4.5.2 stranded three registries
+      # at 4.5.0 here. Asking each registry directly also makes a re-run heal it.
+      - name: Which registries are behind package.json?
+        id: lag
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Target version: ${VERSION}"
+
+          # "behind" = this registry does NOT already have ${VERSION}.
+          # A failed/garbled lookup counts as behind, i.e. we try to publish:
+          # every path below is duplicate-tolerant or version-guarded, so a
+          # redundant attempt is cheap and a skipped one loses a release.
+          behind() {
+            if jq -e --arg v "$VERSION" "$2" >/dev/null 2>&1 <<<"$1"; then echo no; else echo yes; fi
+          }
+
+          PYPI=$(behind "$(curl -sfL https://pypi.org/pypi/smooai-logger/json || true)" '.releases | has($v)')
+          CRATES=$(behind "$(curl -sfL -H 'User-Agent: SmooAI-logger-release' https://crates.io/api/v1/crates/smooai-logger/versions || true)" '[.versions[].num] | index($v)')
+          NUGET=$(behind "$(curl -sfL https://api.nuget.org/v3-flatcontainer/smooai.logger/index.json || true)" '.versions | index($v)')
+          if git ls-remote --exit-code --tags origin "refs/tags/go/v${VERSION}" >/dev/null 2>&1; then GOTAG=no; else GOTAG=yes; fi
+
+          echo "behind -> pypi:${PYPI} crates:${CRATES} nuget:${NUGET} go-tag:${GOTAG}"
+          {
+            echo "pypi=${PYPI}"
+            echo "crates=${CRATES}"
+            echo "nuget=${NUGET}"
+            echo "gotag=${GOTAG}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Publish smooai-logger to PyPI
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.lag.outputs.pypi == 'yes'
         working-directory: python
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.SMOOAI_PYPI_TOKEN }}
@@ -120,13 +155,13 @@ jobs:
           uv run poe publish
 
       - name: Publish smooai-logger to crates.io
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.lag.outputs.crates == 'yes'
         run: cargo publish --locked --manifest-path rust/logger/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.SMOOAI_CARGO_REGISTRY_TOKEN }}
 
       - name: Tag and publish Go module
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.lag.outputs.gotag == 'yes'
         run: |
           # Guard here, not just in the pre-flight checks: changesets has
           # bumped package.json by this point, so this is the only place the
@@ -143,7 +178,7 @@ jobs:
           echo "Go module tagged and pushed: ${TAG}"
 
       - name: Build and test .NET
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.lag.outputs.nuget == 'yes'
         working-directory: dotnet
         run: |
           dotnet restore SmooAI.Logger.sln
@@ -151,7 +186,7 @@ jobs:
           dotnet test SmooAI.Logger.sln -c Release --no-build --nologo
 
       - name: Pack and publish SmooAI.Logger to NuGet
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.lag.outputs.nuget == 'yes'
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "Packing SmooAI.Logger ${VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,19 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "Target version: ${VERSION}"
 
+          # npm is the source of truth for "this version is released". The
+          # changesets action leaves the workspace on the version branch, so in a
+          # run that only OPENS the version PR, package.json is already bumped to
+          # a version nothing has published yet — without this gate the four
+          # steps below would ship it ahead of npm, from an unmerged branch.
+          if ! npm view "@smooai/logger@${VERSION}" version >/dev/null 2>&1; then
+            echo "npm does not have ${VERSION} yet — nothing to backfill."
+            {
+              echo "pypi=no"; echo "crates=no"; echo "nuget=no"; echo "gotag=no"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # "behind" = this registry does NOT already have ${VERSION}.
           # A failed/garbled lookup counts as behind, i.e. we try to publish:
           # every path below is duplicate-tolerant or version-guarded, so a

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "go:fmt": "(cd go && gofmt -w .)",
     "go:fmt:check": "(cd go && test -z \"$(gofmt -l .)\")",
     "go:lint": "(cd go && go vet ./...)",
-    "go:test": "(cd go && go test -v ./...)",
+    "go:test": "(cd go && go test -count=1 -v ./...)",
     "lint": "oxlint . && pnpm run python:lint && pnpm run rust:lint && pnpm run go:lint",
     "lint:fix": "oxlint --fix . && pnpm run python:lint:fix",
     "pre-commit-check": "(zsh .husky/pre-commit)",
@@ -130,7 +130,7 @@
     "rotating-file-stream": "^3.2.6",
     "serialize-error": "^11.0.3",
     "source-map-support": "^0.5.21",
-    "uuid": "^9.0.0",
+    "uuid": "^11.1.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {
@@ -147,7 +147,6 @@
     "@types/lodash.merge": "^4.6.9",
     "@types/node": "^22.13.10",
     "@types/source-map-support": "^0.5.10",
-    "@types/uuid": "^9.0.2",
     "glob": "^11.0.1",
     "oxfmt": "^0.28.0",
     "oxlint": "^0.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^0.5.21
         version: 0.5.21
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^11.1.1
+        version: 11.1.1
       zod:
         specifier: ^4.0.0
         version: 4.1.5
@@ -88,9 +88,6 @@ importers:
       '@types/source-map-support':
         specifier: ^0.5.10
         version: 0.5.10
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.8
       glob:
         specifier: ^11.0.1
         version: 11.0.1
@@ -1124,9 +1121,6 @@ packages:
 
   '@types/source-map-support@0.5.10':
     resolution: {integrity: sha512-tgVP2H469x9zq34Z0m/fgPewGhg/MLClalNOiPIzQlXrSS2YrKu/xCdSCKnEDwkFha51VKEKB6A9wW26/ZNwzA==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@vitest/expect@3.1.1':
     resolution: {integrity: sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==}
@@ -2303,8 +2297,13 @@ packages:
   url-or-path@2.3.2:
     resolution: {integrity: sha512-DOI9KXk0bc/JOmFQHbn25knW2GX/ym7+egKFEFApG3VdDzRlLBMCIrMnruq4AZUGop1W0aiYQ5Vry6clzhxcOQ==}
 
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -3813,8 +3812,6 @@ snapshots:
     dependencies:
       source-map: 0.6.1
 
-  '@types/uuid@9.0.8': {}
-
   '@vitest/expect@3.1.1':
     dependencies:
       '@vitest/spy': 3.1.1
@@ -4824,6 +4821,8 @@ snapshots:
       rolldown: 1.0.1
 
   url-or-path@2.3.2: {}
+
+  uuid@11.1.1: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
Three small fixes from a cross-repo sweep, plus a **verified negative** on the stream question (below).

## 1. `uuid` 9.0.1 → 11.1.1

Advisory: moderate, *missing buffer bounds check in v3/v5/v6 when `buf` is provided*, patched in `>=11.1.1`.

**Not reachable here.** Logger's only call sites are `uuidv4()` with no arguments (`src/Logger.ts:189`, `:573`); v3/v5/v6 are never imported and no `buf` is ever passed. But the advisory propagates to every consumer — `@smooai/config` traced it through three separate paths into its tree and had to add a `pnpm.overrides` pin. Fixing it at the source is cheaper than N overrides. `@types/uuid` dropped; uuid 11 ships its own types.

## 2. Publish steps gate on the registry, not on npm's success

```yaml
if: steps.changesets.outputs.published == 'true'   # ← on PyPI, crates.io, Go tag, NuGet
```

That output is true only when the publish command shipped something **in that run**. So a run that dies after npm leaves the other four behind — and the *next* run, with no changesets left, reports `published=false`, skips all four, and goes **green having published nothing**.

**This happened here today.** 4.5.1 and 4.5.2 reached npm and PyPI while crates.io, NuGet and the Go tag sat at 4.5.0, across runs that reported success. It only got caught because I compared the live registries by hand.

Each step now asks its own registry whether the version is already there:

```bash
PYPI=$(behind "$(curl -sfL https://pypi.org/pypi/smooai-logger/json || true)" '.releases | has($v)')
CRATES=$(behind "$(curl -sfL -H '...' https://crates.io/api/v1/crates/smooai-logger/versions || true)" '[.versions[].num] | index($v)')
NUGET=$(behind "$(curl -sfL https://api.nuget.org/v3-flatcontainer/smooai.logger/index.json || true)" '.versions | index($v)')
git ls-remote --exit-code --tags origin "refs/tags/go/v${VERSION}"
```

Side benefit: a **re-run now heals a partial release** instead of skipping it.

The lookup **fails toward publishing** — a garbled or failed response counts as "behind". Every path below is duplicate-tolerant (`--skip-duplicate` on NuGet) or version-guarded (the Go tag), so a redundant attempt is cheap while a skipped one loses a release.

Verified against the live registries:

| version | pypi | crates | nuget | go-tag |
| --- | :-: | :-: | :-: | :-: |
| 4.5.3 (real) | not behind | not behind | behind ¹ | not behind |
| 9.9.9 (fake) | behind | behind | behind | behind |
| *(empty response)* | behind | — | — | — |

¹ NuGet accepted the 4.5.3 push (HTTP 201, both `.nupkg` and `.snupkg`) but its flat-container index still 404s ~50 min later — nuget.org validation latency, not a failure. This is precisely the case `--skip-duplicate` plus fail-toward-publish handles gracefully.

## 3. `go:test` gains `-count=1`

Go's test cache does not invalidate on fixtures read from outside the package dir, and `go/parity_corpus_test.go` reads `../parity-corpus.json`.

**I checked before changing anything, and Go is currently safe** — it refuses to cache that test at all. Positive control:

```
TestLevelString    (reads nothing outside the pkg)  → ok  (cached)   ← on re-run
TestParityCorpus   (reads ../parity-corpus.json)    → ok  0.296s
                                                    → ok  0.284s     ← never cached
```

I also re-ran the #183 corpus positive control: corrupting the placeholder still fails Go. **So the Go half of that corpus proved what it claimed.** `-count=1` costs nothing and means a five-language parity guarantee no longer rests on that behaviour.

---

## Verified negative: no single-`read()` and no hand-rolled stream mocks

Checked all five languages for the `@smooai/file` defect class. **Logger is clean, and structurally so — it is a log *producer*; it never consumes a stream.** There is no `read()`, `ReadAll`, `read_to_end`, or `.Read(` anywhere in any port (the `.read()` grep hits are iterator `.next()` and `RwLock::read()`).

Every write path uses a loop-until-done primitive:

| port | write path |
| --- | --- |
| TypeScript | `process.stdout.write` + the `rotating-file-stream` library — Node buffers, never truncates |
| Python | stdlib `RotatingFileHandler` / `TimedRotatingFileHandler`, `sys.stdout.write` |
| Rust | `write_all` in both places (`logger.rs:449`, `rotation.rs:87`) — never bare `write` |
| Go | `io.WriteString`; `rotation.go:100` uses `os.File.Write`, whose contract returns a non-nil error when `n != len(b)`, and the code checks it |
| .NET | `FileStream.Write(bytes, 0, bytes.Length)` — writes all or throws |

And no hand-rolled stream mocks. Every test writer is the real runtime type: Go `bytes.Buffer` (`io.Writer`), .NET `StringWriter` (`TextWriter`), Python `io.StringIO`, Rust `tempfile::tempdir` (real files). There is no `vi.mock` in the TS suite at all — `CapturingLogger` overrides the logger's own declared `logFunc` hook, which is not a stream. The only `MagicMock` is a Lambda *context* object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152bbE1veqfG1SVJdyLCBxC