### PR TITLE
Fix the npm read-after-write race I introduced in the publish gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,18 +118,33 @@ jobs:
       # at 4.5.0 here. Asking each registry directly also makes a re-run heal it.
       - name: Which registries are behind package.json?
         id: lag
+        env:
+          CHANGESETS_PUBLISHED: ${{ steps.changesets.outputs.published }}
         run: |
           set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
           echo "Target version: ${VERSION}"
 
-          # npm is the source of truth for "this version is released". The
+          # Is ${VERSION} actually released? Two independent yeses, because
+          # neither alone is sufficient:
+          #
+          #   - changesets published it in THIS run. Authoritative immediately,
+          #     and necessary because npm reads are eventually consistent: a
+          #     `npm view` moments after a successful publish still 404s, which
+          #     skipped all four steps for 4.5.4 and left them a version behind.
+          #   - npm already serves it. This is the backfill path — it lets a
+          #     re-run catch up registries that an earlier run left behind.
+          #
+          # Neither true means package.json is bumped but unreleased. The
           # changesets action leaves the workspace on the version branch, so in a
-          # run that only OPENS the version PR, package.json is already bumped to
-          # a version nothing has published yet — without this gate the four
-          # steps below would ship it ahead of npm, from an unmerged branch.
-          if ! npm view "@smooai/logger@${VERSION}" version >/dev/null 2>&1; then
-            echo "npm does not have ${VERSION} yet — nothing to backfill."
+          # run that only OPENS the version PR this is exactly the case, and
+          # publishing here would ship ahead of npm from an unmerged branch.
+          if [ "${CHANGESETS_PUBLISHED:-false}" = "true" ]; then
+            echo "changesets published ${VERSION} in this run."
+          elif npm view "@smooai/logger@${VERSION}" version >/dev/null 2>&1; then
+            echo "npm already serves ${VERSION} — checking the others for backfill."
+          else
+            echo "${VERSION} is not released (not published here, not on npm) — nothing to do."
             {
               echo "pypi=no"; echo "crates=no"; echo "nuget=no"; echo "gotag=no"
             } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## My bug, from #194, caught in production one release later

#194 replaced `if: steps.changesets.outputs.published == 'true'` with "does npm already serve this version", so a mid-run failure could no longer silently strand four registries. **It reintroduced the same failure through a different door.**

npm registry *reads* are eventually consistent. `npm view @smooai/logger@4.5.4` moments after a successful publish still 404s. So on release run [32407821367](https://github.com/SmooAI/logger/actions/runs/32407821367):

```
Target version: 4.5.4
npm does not have 4.5.4 yet — nothing to backfill.
```

…all four steps skipped and the run went **green**. `npm view @smooai/logger version` returns `4.5.4` now, but the damage is done:

| registry | version |
| --- | --- |
| npm | **4.5.4** |
| PyPI | missing |
| crates.io | missing |
| Go tag | missing |
| NuGet | missing |

Exactly the class of defect #194 set out to kill, caused by the fix for it. Reporting it plainly because a green run that publishes nothing is precisely the thing nobody notices.

## Fix

Two independent signals count as "released", because neither alone is sufficient:

| signal | why it's needed |
| --- | --- |
| `steps.changesets.outputs.published == 'true'` | authoritative the instant it happens, **no registry read involved** — this is the normal path, and the one the race broke |
| npm already serves the version | the **backfill** path: what lets a re-run catch up registries an earlier run left behind, which was the entire point of #194 |

Only when neither holds do the four steps skip — correctly, because that is a run that merely *opened* the version PR, where `package.json` is bumped to something nothing has published and the workspace is sitting on an unmerged branch. (That case is real; it's why #194 gained the npm gate at all, and it worked: run 32407587838 logged `npm does not have 4.5.4 yet` and correctly published nothing.)

## Deliberately no changeset

`package.json` stays at 4.5.4, so merging this takes the **backfill path** and ships 4.5.4 to the four registries it's missing from. A changeset would bump to 4.5.5 and strand 4.5.4 permanently.

This also serves as the live test of the backfill path against a real drift.

## Verification

All three release states, by hand:

```
just-published (npm may still 404)     -> PROCEED (published this run)
backfill: npm serves it                -> PROCEED (npm serves it — backfill)
version PR only, unreleased            -> SKIP ALL FOUR
```

`pnpm format:check` clean; `check-versions: OK (all manifests at 4.5.4)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152bbE1veqfG1SVJdyLCBxC