### PR TITLE
chore(ci): bump Go toolchain to 1.26

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -12,5 +12,5 @@
 [tools]
 node = "24.14.0" # ships npm 11.9.0 — required (>=11.5.1) for npm OIDC trusted publishing
 python = "3.13"
-go = "1.25"
+go = "1.26"
 uv = "latest"


### PR DESCRIPTION
Bumps the Go toolchain to 1.26. Since the mise migration the version lives only in `mise.toml`, so this is a one-line change.

Deliberately **not** touching the `go` directive in `go/go.mod` — that declares the minimum language version for consumers of the published module, and raising it would break them.

Verified locally on go1.26.7 in `go/`:
- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — `ok github.com/SmooAI/logger/go/v4 0.578s`
- `gofmt -l .` — no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YaefW6U442PHZf94fMAer
